### PR TITLE
feat(gascity): role workers never hunt for a worktree — gc chooses the workspace

### DIFF
--- a/gascity/README.md
+++ b/gascity/README.md
@@ -221,8 +221,8 @@ root whose `AGENTS` rules forbade working there created its own
 role prompts.)
 
 This pack ships `assets/scripts/worker-worktree.sh` for the `pre_start` half.
-Copy it into the city's scripts directory, which gc mirrors into every session
-work dir (gc does not sync a pack's `assets/scripts` there):
+Copy it into the city's scripts directory, `.gc/scripts` (gc does not sync a
+pack's `assets/scripts` there), and reference it through `{{.CityRoot}}`:
 
 ```sh
 cp path/to/gascity/assets/scripts/worker-worktree.sh "$CITY/.gc/scripts/"
@@ -253,9 +253,12 @@ pre_start = ["sh {{.CityRoot}}/.gc/scripts/worker-worktree.sh"]
 A second role instance on another provider (an `agents/<name>/agent.toml`,
 see the repository README, "Codex code workers") carries the same two keys
 directly. `{{.AgentBase}}` is the agent identity gc resolves the session
-under: a singleton agent (`max_active_sessions = 1`) keeps one lane across
-sessions, so the script's reuse path (fetch, switch to the new bead's branch)
-applies; `gc session list` shows each live session's work dir.
+under. A pool slot is named `<role>-<slot>`, so concurrent sessions of one
+role get distinct lanes (`lane-gc.implementation-worker-1`,
+`lane-gc.implementation-worker-3`, …) and never share a checkout; a singleton
+agent (`max_active_sessions = 1`) keeps one lane across sessions, so the
+script's reuse path (fetch, switch to the new bead's branch) applies.
+`gc session list` shows each live session's work dir.
 
 The pack does not set these keys on its role agents by default. The
 `pre_start` half needs the script installed in the city's `.gc/scripts`, and

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -206,33 +206,64 @@ and `gc.publisher`.
 
 ## Worker workspaces
 
-A rig role agent starts in the rig root unless its `work_dir` says otherwise.
-Rigs whose `AGENTS` rules forbid working in the root (a shared checkout that
-lags `origin/main`, other agents' branches) give each worker its own worktree
-before the first turn, using two core surfaces: `work_dir` (gc creates it,
+The unit of isolation is the agent. A rig role agent starts in the rig root
+unless its `work_dir` says otherwise; in the standard model every role agent
+that reads or writes a rig's source has one. gc creates the `work_dir`,
 starts the session in it, exports it as `$GC_DIR`, and materializes the
-agent's skills and hooks into it because it differs from the scope root) and
-`pre_start` (runs before the session, in `$GC_DIR`, with the session
-environment, including `GC_TRIGGER_BEAD_ID` for a slung bead).
+agent's skills and hooks into it (because it differs from the scope root); a
+`pre_start` command runs before the session, in `$GC_DIR`, with the session
+environment (`GC_TRIGGER_BEAD_ID` for a slung bead), and makes that
+directory a git worktree of the rig on the bead's branch. Workers never
+choose, create, or hunt for a workspace, and the rig root stays a human
+checkout that no agent touches. (Earlier, a worker that started in a rig
+root whose `AGENTS` rules forbade working there created its own
+`.worktrees/<rig>/<bead>` from a prompt rule; that rule is gone from the
+role prompts.)
 
 This pack ships `assets/scripts/worker-worktree.sh` for the `pre_start` half.
 Copy it into the city's scripts directory, which gc mirrors into every session
-work dir, and point the agent at it:
+work dir (gc does not sync a pack's `assets/scripts` there):
 
 ```sh
 cp path/to/gascity/assets/scripts/worker-worktree.sh "$CITY/.gc/scripts/"
 ```
 
+Wire the roles per city with `[[patches.agent]]` in `city.toml`, the
+documented surface for overriding an imported pack agent's fields
+(`work_dir` and `pre_start` are both patchable; `rig = "*"` reaches the role
+in every rig; the bare role name matches the pack agent whatever import
+alias the city gave it). One entry per role. Give the read-only roles
+(reviewers, analysts, planners) a lane too, so no role ever starts in the
+rig root; for them the script's reuse path is a fetch and a checkout.
+
 ```toml
-# agents/implementation-worker-codex/agent.toml — a second role instance on
-# another provider (see the repository README, "Codex code workers"); the same
-# two keys work in a [[rigs.patches]] or [[patches.agent]] entry.
-scope = "rig"
-dir = "my-repo"
-provider = "codex"
+# city.toml — every gc role agent starts in its own lane worktree.
+[[patches.agent]]
+rig = "*"
+name = "implementation-worker"
 work_dir = ".worktrees/{{.Rig}}/lane-{{.AgentBase}}"
 pre_start = ["sh {{.CityRoot}}/.gc/scripts/worker-worktree.sh"]
+
+# Repeat the entry for the other roles this pack ships: publisher,
+# run-operator, review-synthesizer, design-author, requirements-planner,
+# task-decomposer, issue-triager, implementation-reviewer,
+# design-implementation-reviewer, design-test-risk-reviewer, gap-analyst.
 ```
+
+A second role instance on another provider (an `agents/<name>/agent.toml`,
+see the repository README, "Codex code workers") carries the same two keys
+directly. `{{.AgentBase}}` is the agent identity gc resolves the session
+under: a singleton agent (`max_active_sessions = 1`) keeps one lane across
+sessions, so the script's reuse path (fetch, switch to the new bead's branch)
+applies; `gc session list` shows each live session's work dir.
+
+The pack does not set these keys on its role agents by default. The
+`pre_start` half needs the script installed in the city's `.gc/scripts`, and
+a `pre_start` that fails aborts the session start by design, so a pack-level
+default would stop every role session in a city that has not installed it;
+which roles need filesystem isolation is a deployment decision in gc's
+model. `gc doctor` reports a `pre_start` script referenced via
+`{{.CityRoot}}` that is missing on disk.
 
 The script makes `$GC_DIR` a worktree of `$GC_RIG_ROOT`'s repository and
 never touches the rig root's working tree; the rig root, anything inside it,

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -216,14 +216,12 @@ environment (`GC_TRIGGER_BEAD_ID` for a slung bead), and makes that
 directory a git worktree of the rig on the bead's branch. Workers never
 choose, create, or hunt for a workspace, and the rig root stays a human
 checkout that no agent touches. A role the city gave no `work_dir` still
-starts in the rig root; the role prompt's one fallback then has it create
-`<city>/.worktrees/<rig>/<bead>` and mail the mayor for a lane, whatever the
-rig's own rules say. The fallback resolves its base the way the script does
-(the remote's default branch when the rig has a remote, whatever its name,
-else the rig checkout's `HEAD`), so a local-only rig, or one whose remote is
-not named `origin`, still gets a workspace, and the rig checkout's HEAD never
-moves. (The earlier prompt rule that keyed this on the rig's `AGENTS` rules
-forbidding root work is gone.)
+starts in the rig root and has no lane; the role prompt then has it create no
+worktree and write nothing there, whatever the rig's own rules say: it reads
+by `git show` and `git log` only, and a step that needs a checkout closes with
+`gc.outcome=fail` and `gc.failure_class=no-lane`, naming the fix, a lane for
+the role (the `[[patches.agent]]` entry below). No prompt-side path makes a
+workspace for an unconfigured role.
 
 This pack ships `assets/scripts/worker-worktree.sh` for the `pre_start` half.
 Copy it into the city's scripts directory, `.gc/scripts` (gc does not sync a
@@ -310,10 +308,13 @@ test in `do-work/prepare-worktree` step 4: the resolved top-level is `$GC_DIR`
 itself, not the rig root or inside it, and the git common dir is the rig's);
 a role with no `work_dir` starts in the rig root, and a reader there reads by
 `git show` only and never detaches the human checkout. After the fix lane
-commits it refreshes the recorded commit (the review context file and
-`gc.build.review_commit` on the workflow root) before it releases the branch,
-so the next review attempt inspects the fixed code, not the commit the setup
-saw.
+commits it refreshes the recorded commit of the item it fixed (that source
+anchor's record in the review context file and `gc.review_commit` on that
+source anchor, never a workflow-wide key: separate drains put several items
+on independent branches, each reviewed at its own commit) before it releases
+the branch, so the next review attempt inspects the fixed code, not the
+commit the setup saw, and the other items' recorded commits stay as they
+were.
 
 Two related core behaviors complete the picture:
 

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -235,16 +235,25 @@ pre_start = ["sh {{.CityRoot}}/.gc/scripts/worker-worktree.sh"]
 ```
 
 The script makes `$GC_DIR` a worktree of `$GC_RIG_ROOT`'s repository and
-never touches the rig root's working tree. With a trigger bead it reuses the
-one branch whose name contains the bead id (local or on the remote) or
-creates `<bead id>` from `origin/HEAD`; a branch checked out in another
-worktree is not stolen (the lane is left detached at its tip, with a WARN).
-Nothing is ever deleted: a lane with tracked modifications, or a non-empty
-directory that is not a worktree, is moved to `<lane>.aside-<utc stamp>`
-first. Untracked files (materialized skills, hooks, `node_modules`) do not
-count as modifications. Because the lane is on the bead's branch when the
-worker claims, `gc hook --claim` stamps a correct `gc.work_branch` instead of
-inheriting a stale one. `sh worker-worktree.sh --help` lists the flags.
+never touches the rig root's working tree; the rig root, anything inside it,
+and any ancestor of it are refused up front. Runs on one repository are
+serialized by a lock in its git dir, so concurrent sessions cannot race on a
+branch or a lane. With a trigger bead it reuses the one branch whose name
+contains the bead id as a whole token (local or on the remote) or creates
+`<bead id>` from `origin/HEAD`; a branch checked out in another worktree is
+not stolen (the lane is left detached at its tip, with a WARN). Nothing is
+ever deleted: a lane with tracked modifications, or a non-empty directory
+that is not a git checkout, is moved to `<lane>.aside-<utc stamp>` first; a
+checkout of another repository is refused. Untracked files (materialized
+skills, hooks, `node_modules`) do not count as modifications. `sh
+worker-worktree.sh --help` prints the full contract.
+
+The lane is on the bead's branch when the worker claims. With a gascity that
+resolves the work branch from the session work dir (`hookClaimWorkBranchDir`,
+the companion core change), `gc hook --claim` then stamps a correct
+`gc.work_branch`; older builds read the rig root's branch, so the role prompt
+has the worker compare `gc.work_branch` with its branch after the claim and
+restamp it when they differ.
 
 Two related core behaviors complete the picture:
 

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -218,8 +218,12 @@ choose, create, or hunt for a workspace, and the rig root stays a human
 checkout that no agent touches. A role the city gave no `work_dir` still
 starts in the rig root; the role prompt's one fallback then has it create
 `<city>/.worktrees/<rig>/<bead>` and mail the mayor for a lane, whatever the
-rig's own rules say. (The earlier prompt rule that keyed this on the rig's
-`AGENTS` rules forbidding root work is gone.)
+rig's own rules say. The fallback resolves its base the way the script does
+(the remote's default branch when the rig has a remote, whatever its name,
+else the rig checkout's `HEAD`), so a local-only rig, or one whose remote is
+not named `origin`, still gets a workspace, and the rig checkout's HEAD never
+moves. (The earlier prompt rule that keyed this on the rig's `AGENTS` rules
+forbidding root work is gone.)
 
 This pack ships `assets/scripts/worker-worktree.sh` for the `pre_start` half.
 Copy it into the city's scripts directory, `.gc/scripts` (gc does not sync a
@@ -275,8 +279,11 @@ and any ancestor of it are refused up front. Runs on one repository are
 serialized by a lock in its git dir, so concurrent sessions cannot race on a
 branch or a lane. With a trigger bead it reuses the one branch whose name
 contains the bead id as a whole token (local or on the remote) or creates
-`<bead id>` from `origin/HEAD`; a branch checked out in another worktree is
-not stolen (the lane is left detached at its tip, with a WARN). Nothing is
+`<bead id>` from a resolved base: `<remote>/HEAD`, else `<remote>/main`, else
+`<remote>/master`, else the rig root's `HEAD` with a WARN (the remote is
+`origin` unless `--remote` names another; `--base` overrides); a branch
+checked out in another worktree is not stolen (the lane is left detached at
+its tip, with a WARN). Nothing is
 ever deleted: a lane with tracked modifications, or a non-empty directory
 that is not a git checkout, is moved to `<lane>.aside-<utc stamp>` first; a
 checkout of another repository is refused. Untracked files (materialized

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -215,10 +215,11 @@ agent's skills and hooks into it (because it differs from the scope root); a
 environment (`GC_TRIGGER_BEAD_ID` for a slung bead), and makes that
 directory a git worktree of the rig on the bead's branch. Workers never
 choose, create, or hunt for a workspace, and the rig root stays a human
-checkout that no agent touches. (Earlier, a worker that started in a rig
-root whose `AGENTS` rules forbade working there created its own
-`.worktrees/<rig>/<bead>` from a prompt rule; that rule is gone from the
-role prompts.)
+checkout that no agent touches. A role the city gave no `work_dir` still
+starts in the rig root; the role prompt's one fallback then has it create
+`<city>/.worktrees/<rig>/<bead>` and mail the mayor for a lane, whatever the
+rig's own rules say. (The earlier prompt rule that keyed this on the rig's
+`AGENTS` rules forbidding root work is gone.)
 
 This pack ships `assets/scripts/worker-worktree.sh` for the `pre_start` half.
 Copy it into the city's scripts directory, `.gc/scripts` (gc does not sync a

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -204,6 +204,59 @@ Default formula routes use these qualified targets: `gc.run-operator`,
 `gc.implementation-worker`, `gc.gap-analyst`, `gc.implementation-reviewer`,
 and `gc.publisher`.
 
+## Worker workspaces
+
+A rig role agent starts in the rig root unless its `work_dir` says otherwise.
+Rigs whose `AGENTS` rules forbid working in the root (a shared checkout that
+lags `origin/main`, other agents' branches) give each worker its own worktree
+before the first turn, using two core surfaces: `work_dir` (gc creates it,
+starts the session in it, exports it as `$GC_DIR`, and materializes the
+agent's skills and hooks into it because it differs from the scope root) and
+`pre_start` (runs before the session, in `$GC_DIR`, with the session
+environment, including `GC_TRIGGER_BEAD_ID` for a slung bead).
+
+This pack ships `assets/scripts/worker-worktree.sh` for the `pre_start` half.
+Copy it into the city's scripts directory, which gc mirrors into every session
+work dir, and point the agent at it:
+
+```sh
+cp path/to/gascity/assets/scripts/worker-worktree.sh "$CITY/.gc/scripts/"
+```
+
+```toml
+# agents/implementation-worker-codex/agent.toml — a second role instance on
+# another provider (see the repository README, "Codex code workers"); the same
+# two keys work in a [[rigs.patches]] or [[patches.agent]] entry.
+scope = "rig"
+dir = "my-repo"
+provider = "codex"
+work_dir = ".worktrees/{{.Rig}}/lane-{{.AgentBase}}"
+pre_start = ["sh {{.CityRoot}}/.gc/scripts/worker-worktree.sh"]
+```
+
+The script makes `$GC_DIR` a worktree of `$GC_RIG_ROOT`'s repository and
+never touches the rig root's working tree. With a trigger bead it reuses the
+one branch whose name contains the bead id (local or on the remote) or
+creates `<bead id>` from `origin/HEAD`; a branch checked out in another
+worktree is not stolen (the lane is left detached at its tip, with a WARN).
+Nothing is ever deleted: a lane with tracked modifications, or a non-empty
+directory that is not a worktree, is moved to `<lane>.aside-<utc stamp>`
+first. Untracked files (materialized skills, hooks, `node_modules`) do not
+count as modifications. Because the lane is on the bead's branch when the
+worker claims, `gc hook --claim` stamps a correct `gc.work_branch` instead of
+inheriting a stale one. `sh worker-worktree.sh --help` lists the flags.
+
+Two related core behaviors complete the picture:
+
+- A bead carrying `work_dir=<absolute path>` metadata, assigned and in
+  progress, starts its next session in that directory (an existing per-bead
+  worktree wins over the agent's lane). The role prompt tells workers to stamp
+  it, with `gc.work_branch`, before closing a bead whose work continues.
+- Toolchain on the worker PATH belongs to the provider: `[providers.<name>]
+  env = { PATH = "..." }` (values expand `$VAR` against the controller
+  environment) or a command shim that prepends a directory of wrappers. The
+  role prompt does not install package managers.
+
 ## Build Methodology Contract
 
 `build-base` is the virtual full-lifecycle workflow contract. It defines the

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -290,6 +290,15 @@ the companion core change), `gc hook --claim` then stamps a correct
 has the worker compare `gc.work_branch` with its branch after the claim and
 restamp it when they differ.
 
+Inside a formula the branch is also the handoff between lanes, under one
+lifecycle: a lane holds the item's branch only while it is writing to it and
+releases it (`git switch --detach`) when it hands off, because git allows one
+worktree per branch; every reader inspects the recorded commit detached in its
+own lane (`git switch --detach <commit>`, `git show <commit>:<path>`), so
+parallel reviewers never contend and the fix lane finds the branch free. A
+branch left held by a crashed writer is released by the operator from that
+lane, never by another agent's step.
+
 Two related core behaviors complete the picture:
 
 - A bead carrying `work_dir=<absolute path>` metadata, assigned and in

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -297,7 +297,16 @@ worktree per branch; every reader inspects the recorded commit detached in its
 own lane (`git switch --detach <commit>`, `git show <commit>:<path>`), so
 parallel reviewers never contend and the fix lane finds the branch free. A
 branch left held by a crashed writer is released by the operator from that
-lane, never by another agent's step.
+lane, never by another agent's step. Every lane, writer or reader, proves it
+is a lane before it switches or detaches anything (the three-part boundary
+test in `do-work/prepare-worktree` step 4: the resolved top-level is `$GC_DIR`
+itself, not the rig root or inside it, and the git common dir is the rig's);
+a role with no `work_dir` starts in the rig root, and a reader there reads by
+`git show` only and never detaches the human checkout. After the fix lane
+commits it refreshes the recorded commit (the review context file and
+`gc.build.review_commit` on the workflow root) before it releases the branch,
+so the next review attempt inspects the fixed code, not the commit the setup
+saw.
 
 Two related core behaviors complete the picture:
 

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -1,0 +1,277 @@
+#!/bin/sh
+# worker-worktree.sh — make a worker session's working directory a git
+# worktree of its rig, before the first turn.
+#
+# Built to run as a Gas City agent `pre_start` command. gc creates `work_dir`,
+# then runs pre_start with cwd = $GC_DIR and the session environment, then
+# stages skills/hooks into the same directory and starts the provider there.
+#
+#   # agents/<name>/agent.toml (or a [[patches.agent]] entry)
+#   work_dir  = ".worktrees/{{.Rig}}/lane-{{.AgentBase}}"
+#   pre_start = ["sh {{.CityRoot}}/.gc/scripts/worker-worktree.sh"]
+#
+# Inputs (flags win over environment):
+#   --workdir DIR    directory to turn into a worktree   (default $GC_DIR, else $PWD)
+#   --rig-root DIR   the rig checkout whose repository to use (default $GC_RIG_ROOT)
+#   --bead ID        bead whose branch to reuse or create (default $GC_TRIGGER_BEAD_ID;
+#                    empty leaves the worktree detached at --base)
+#   --base REF       start point for a new branch (default <remote>/HEAD, else <remote>/main)
+#   --remote NAME    remote to fetch and match branches on (default origin)
+#   --no-fetch       do not fetch before resolving refs
+#
+# Contract:
+#   * The rig root's working tree is never touched: the script only reads
+#     refs, fetches, and registers worktrees from it.
+#   * Nothing is deleted. A work dir that is not a worktree of this repository
+#     and is not empty is moved to <workdir>.aside-<utc stamp>; a worktree with
+#     tracked modifications is moved aside the same way before a fresh one
+#     replaces it. Untracked files (staged skills, hooks, node_modules) do not
+#     count as modifications and ride along on a branch switch.
+#   * Bead branch: exactly one branch (local or on the remote) whose name
+#     contains the bead id is reused. None: a new branch named <bead id> is
+#     created from --base. Several: fail closed and list them.
+#   * A bead branch already checked out in another worktree is not stolen: the
+#     work dir is left detached at that branch's tip and a WARN line names the
+#     other worktree.
+#   * Idempotent. Re-running on a work dir that is already on the right branch
+#     changes nothing (besides the fetch).
+#   * On success prints one line: WORKTREE <dir> <branch|detached> <head sha>.
+
+set -eu
+
+log() { printf 'worker-worktree: %s\n' "$*" >&2; }
+warn() { printf 'worker-worktree: WARN %s\n' "$*" >&2; }
+die() { printf 'worker-worktree: ERROR %s\n' "$*" >&2; exit 1; }
+
+WORKDIR="${GC_DIR:-}"
+RIG_ROOT="${GC_RIG_ROOT:-}"
+BEAD="${GC_TRIGGER_BEAD_ID:-}"
+BASE=""
+REMOTE="origin"
+FETCH=1
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --workdir) [ "$#" -ge 2 ] || die "--workdir needs a value"; WORKDIR="$2"; shift 2 ;;
+        --workdir=*) WORKDIR="${1#--workdir=}"; shift ;;
+        --rig-root) [ "$#" -ge 2 ] || die "--rig-root needs a value"; RIG_ROOT="$2"; shift 2 ;;
+        --rig-root=*) RIG_ROOT="${1#--rig-root=}"; shift ;;
+        --bead) [ "$#" -ge 2 ] || die "--bead needs a value"; BEAD="$2"; shift 2 ;;
+        --bead=*) BEAD="${1#--bead=}"; shift ;;
+        --base) [ "$#" -ge 2 ] || die "--base needs a value"; BASE="$2"; shift 2 ;;
+        --base=*) BASE="${1#--base=}"; shift ;;
+        --remote) [ "$#" -ge 2 ] || die "--remote needs a value"; REMOTE="$2"; shift 2 ;;
+        --remote=*) REMOTE="${1#--remote=}"; shift ;;
+        --no-fetch) FETCH=0; shift ;;
+        -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
+
+[ -n "$WORKDIR" ] || WORKDIR="$PWD"
+[ -n "$RIG_ROOT" ] || die "no rig root: pass --rig-root or set GC_RIG_ROOT"
+[ -d "$RIG_ROOT" ] || die "rig root is not a directory: $RIG_ROOT"
+command -v git >/dev/null 2>&1 || die "git is required on PATH"
+
+# Resolve to absolute, physical paths so worktree bookkeeping compares cleanly.
+abs() { (cd "$1" 2>/dev/null && pwd -P); }
+RIG_ROOT="$(abs "$RIG_ROOT")" || die "cannot enter rig root"
+case "$WORKDIR" in
+    /*) ;;
+    *) WORKDIR="$PWD/$WORKDIR" ;;
+esac
+
+RIG_COMMON="$(git -C "$RIG_ROOT" rev-parse --git-common-dir 2>/dev/null)" \
+    || die "rig root is not a git repository: $RIG_ROOT"
+case "$RIG_COMMON" in
+    /*) ;;
+    *) RIG_COMMON="$RIG_ROOT/$RIG_COMMON" ;;
+esac
+RIG_COMMON="$(abs "$RIG_COMMON")" || die "cannot resolve the rig's git dir"
+
+# The work dir must not be the rig root itself or sit inside its checkout.
+if [ -d "$WORKDIR" ]; then
+    WORKDIR_ABS="$(abs "$WORKDIR")"
+    [ "$WORKDIR_ABS" != "$RIG_ROOT" ] || die "work dir is the rig root; give the agent a work_dir outside it"
+    case "$WORKDIR_ABS/" in
+        "$RIG_ROOT"/*) die "work dir $WORKDIR_ABS is inside the rig root $RIG_ROOT" ;;
+    esac
+    WORKDIR="$WORKDIR_ABS"
+fi
+
+git_rig() { git -C "$RIG_ROOT" "$@"; }
+
+if [ "$FETCH" -eq 1 ]; then
+    if ! git_rig fetch --quiet --prune "$REMOTE" 2>/dev/null; then
+        warn "fetch from $REMOTE failed; continuing with the refs already present"
+    fi
+fi
+
+if [ -z "$BASE" ]; then
+    if BASE="$(git_rig symbolic-ref --quiet --short "refs/remotes/$REMOTE/HEAD" 2>/dev/null)"; then
+        :
+    elif git_rig show-ref --verify --quiet "refs/remotes/$REMOTE/main"; then
+        BASE="$REMOTE/main"
+    elif git_rig show-ref --verify --quiet "refs/remotes/$REMOTE/master"; then
+        BASE="$REMOTE/master"
+    else
+        BASE="HEAD"
+        warn "no $REMOTE/HEAD, $REMOTE/main or $REMOTE/master; new branches start at the rig root's HEAD"
+    fi
+fi
+git_rig rev-parse --verify --quiet "$BASE^{commit}" >/dev/null || die "base ref does not resolve: $BASE"
+
+# --- bead branch resolution -------------------------------------------------
+# TARGET_LOCAL: local branch to check out.  TARGET_REMOTE: remote branch to track
+# when no local branch exists.  TARGET_NEW: branch to create from BASE.
+TARGET_LOCAL=""
+TARGET_REMOTE=""
+TARGET_NEW=""
+if [ -n "$BEAD" ]; then
+    candidates="$(
+        {
+            git_rig for-each-ref --format='%(refname:short)' refs/heads
+            git_rig for-each-ref --format='%(refname:short)' "refs/remotes/$REMOTE" \
+                | grep -v "^$REMOTE/HEAD\$" | sed "s|^$REMOTE/||"
+        } | grep -F -- "$BEAD" | sort -u
+    )" || true
+    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
+    if [ "$count" -gt 1 ]; then
+        die "several branches name bead $BEAD; pass --bead with a unique id or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
+    elif [ "$count" -eq 1 ]; then
+        if git_rig show-ref --verify --quiet "refs/heads/$candidates"; then
+            TARGET_LOCAL="$candidates"
+        else
+            TARGET_REMOTE="$candidates"
+        fi
+    else
+        TARGET_NEW="$BEAD"
+    fi
+fi
+
+# Where (if anywhere) is a local branch checked out?  Prints the worktree path.
+checked_out_at() {
+    git_rig worktree list --porcelain | awk -v want="refs/heads/$1" '
+        $1 == "worktree" { wt = $2 }
+        $1 == "branch" && $2 == want { print wt }
+    '
+}
+
+move_aside() {
+    stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    aside="$1.aside-$stamp"
+    n=0
+    while [ -e "$aside" ]; do n=$((n + 1)); aside="$1.aside-$stamp-$n"; done
+    if git -C "$1" rev-parse --git-common-dir >/dev/null 2>&1 \
+        && [ "$(abs "$(git -C "$1" rev-parse --git-common-dir)")" = "$RIG_COMMON" ]; then
+        git_rig worktree move "$1" "$aside" >/dev/null 2>&1 || mv "$1" "$aside"
+    else
+        mv "$1" "$aside"
+    fi
+    warn "moved aside $1 -> $aside ($2); nothing was deleted"
+}
+
+# --- classify the work dir ----------------------------------------------------
+IS_WORKTREE=0
+if [ -d "$WORKDIR" ] && [ -e "$WORKDIR/.git" ]; then
+    wd_common="$(git -C "$WORKDIR" rev-parse --git-common-dir 2>/dev/null || true)"
+    case "$wd_common" in
+        "") ;;
+        /*) ;;
+        *) wd_common="$WORKDIR/$wd_common" ;;
+    esac
+    if [ -n "$wd_common" ] && [ -d "$wd_common" ] && [ "$(abs "$wd_common")" = "$RIG_COMMON" ]; then
+        IS_WORKTREE=1
+    fi
+fi
+
+if [ "$IS_WORKTREE" -eq 0 ] && [ -d "$WORKDIR" ]; then
+    if [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
+        move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
+    fi
+fi
+
+if [ "$IS_WORKTREE" -eq 1 ]; then
+    if [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+        move_aside "$WORKDIR" "tracked modifications present"
+        IS_WORKTREE=0
+    fi
+fi
+
+# --- act ----------------------------------------------------------------------
+add_worktree() {
+    # $1 = mode: local|remote|new|detached
+    [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
+    case "$1" in
+        local)    git_rig worktree add --quiet "$WORKDIR" "$TARGET_LOCAL" ;;
+        remote)   git_rig worktree add --quiet --track -b "$TARGET_REMOTE" "$WORKDIR" "$REMOTE/$TARGET_REMOTE" ;;
+        new)      git_rig worktree add --quiet -b "$TARGET_NEW" "$WORKDIR" "$BASE" ;;
+        detached) git_rig worktree add --quiet --detach "$WORKDIR" "$2" ;;
+    esac
+}
+
+switch_worktree() {
+    # $1 = mode as above; the work dir is a clean worktree already.
+    case "$1" in
+        local)    git -C "$WORKDIR" switch --quiet "$TARGET_LOCAL" ;;
+        remote)   git -C "$WORKDIR" switch --quiet -c "$TARGET_REMOTE" --track "$REMOTE/$TARGET_REMOTE" ;;
+        new)      git -C "$WORKDIR" switch --quiet -c "$TARGET_NEW" "$BASE" ;;
+        detached) git -C "$WORKDIR" switch --quiet --detach "$2" ;;
+    esac
+}
+
+MODE=""
+DETACH_AT=""
+if [ -n "$TARGET_LOCAL" ]; then
+    elsewhere="$(checked_out_at "$TARGET_LOCAL" | grep -v -x -F -- "$WORKDIR" || true)"
+    if [ -n "$elsewhere" ]; then
+        MODE="detached"
+        DETACH_AT="$TARGET_LOCAL"
+        warn "branch $TARGET_LOCAL is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch before committing, or work in that worktree."
+    else
+        MODE="local"
+    fi
+elif [ -n "$TARGET_REMOTE" ]; then
+    MODE="remote"
+elif [ -n "$TARGET_NEW" ]; then
+    MODE="new"
+else
+    MODE="detached"
+    DETACH_AT="$BASE"
+fi
+
+if [ "$IS_WORKTREE" -eq 1 ]; then
+    current="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+    case "$MODE" in
+        local)  [ "$current" = "$TARGET_LOCAL" ] || switch_worktree local ;;
+        remote) switch_worktree remote ;;
+        new)    if git_rig show-ref --verify --quiet "refs/heads/$TARGET_NEW"; then
+                    # Created by a concurrent run between resolution and now.
+                    TARGET_LOCAL="$TARGET_NEW"; switch_worktree local
+                else
+                    switch_worktree new
+                fi ;;
+        detached)
+                if [ -n "$BEAD" ]; then
+                    switch_worktree detached "$DETACH_AT"
+                elif [ "$current" = "HEAD" ]; then
+                    # No bead and already detached: refresh to the base tip.
+                    switch_worktree detached "$DETACH_AT"
+                fi
+                # No bead and on a branch: leave the lane where a previous
+                # session put it; the worker owns that branch.
+                ;;
+    esac
+else
+    if [ "$MODE" = "detached" ]; then
+        add_worktree detached "$DETACH_AT"
+    else
+        add_worktree "$MODE"
+    fi
+fi
+
+WORKDIR="$(abs "$WORKDIR")"
+branch="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+[ "$branch" != "HEAD" ] || branch="detached"
+sha="$(git -C "$WORKDIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+printf 'WORKTREE %s %s %s\n' "$WORKDIR" "$branch" "$sha"

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -27,8 +27,9 @@
 #     no owner published for two minutes) is cleared only under a second,
 #     atomic reclaim lock and only after re-checking it is still the same stale
 #     lock, so two contenders cannot both clear it and a live lock is never
-#     removed. Two sessions preparing lanes at once therefore cannot race on
-#     branch creation, on the same lane, or on the aside destination.
+#     removed; a reclaim lock stuck for two minutes fails the run closed. Two
+#     sessions preparing lanes at once therefore cannot race on branch
+#     creation, on the same lane, or on the aside destination.
 #   * The work dir is resolved on the real filesystem: it must exist, or its
 #     parent must exist and its last component must be a plain name (no `.`,
 #     `..`, or deeper missing levels). Symlinks resolve. The rig root itself,
@@ -148,7 +149,9 @@ git_rig() { git -C "$RIG_ROOT" "$@"; }
 # and finds it still stale: a contender that observed the stale lock, lost the
 # race, and arrives late finds a live owner (or no lock) under the reclaim lock
 # and does nothing. So a live lock is never removed by a late contender. A
-# reclaim lock left by a crash ages out after two minutes. Test-only pauses
+# reclaim lock left by a crash is never removed automatically (removing it by
+# age would reopen the same race one level down): after two minutes the script
+# fails closed and names the directory for an operator. Test-only pauses
 # (WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM / _AFTER_ACQUIRE, seconds) exist so
 # the two-contender interleavings can be exercised deterministically.
 
@@ -181,14 +184,14 @@ RECLAIM="$LOCK.reclaim"
 # lock turned out live or gone, or the reclaim lock itself is stuck).
 reclaim_stale_lock() {
     if ! mkdir "$RECLAIM" 2>/dev/null; then
-        # Someone else is reclaiming; a reclaim lock older than two minutes is a
-        # crash residue and is removed so the next pass can proceed.
+        # Someone else is reclaiming. A reclaim lock older than two minutes is a
+        # crash residue; it is not removed here (two contenders removing it would
+        # race exactly like the primary lock) — fail closed and name it.
         if [ -n "$(find "$RECLAIM" -maxdepth 0 -mmin +2 2>/dev/null)" ]; then
-            rmdir "$RECLAIM" 2>/dev/null || true
+            die "stale reclaim lock $RECLAIM is older than two minutes; remove it by hand after checking no worker-worktree run is alive"
         fi
         return 1
     fi
-    [ -z "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
     cleared=1
     if lock_is_stale; then
         warn "clearing stale lock $LOCK (owner pid ${owner:-none})"
@@ -218,8 +221,11 @@ while :; do
         [ -z "${WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE"
         break
     fi
-    if lock_is_stale && reclaim_stale_lock; then
-        continue
+    if lock_is_stale; then
+        [ -z "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
+        if reclaim_stale_lock; then
+            continue
+        fi
     fi
     # Live lock, or a reclaim that did not clear anything: bounded wait.
     [ "$waited" -lt "$LOCK_WAIT" ] || die "another worker-worktree run (pid ${owner:-unknown}) has held $LOCK for ${LOCK_WAIT}s"

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -22,10 +22,12 @@
 #
 # Contract:
 #   * One path, serialized. Every run on a repository takes the lock
-#     <git common dir>/worker-worktree.lock before it reads or changes anything
-#     and releases it on exit; a lock whose owning pid is gone is cleared. So
-#     two sessions preparing lanes at once cannot race on branch creation, on
-#     the same lane, or on the aside destination.
+#     <git common dir>/worker-worktree.lock (mkdir) before it reads or changes
+#     anything and releases it on exit. A stale lock (owner dead or a zombie, or
+#     no owner published for two minutes) is reclaimed by an atomic rename, so
+#     two contenders cannot both clear it and a live lock is never removed. Two
+#     sessions preparing lanes at once therefore cannot race on branch
+#     creation, on the same lane, or on the aside destination.
 #   * The work dir is resolved on the real filesystem: it must exist, or its
 #     parent must exist and its last component must be a plain name (no `.`,
 #     `..`, or deeper missing levels). Symlinks resolve. The rig root itself,
@@ -92,9 +94,10 @@ done
 [ -d "$RIG_ROOT" ] || die "rig root is not a directory: $RIG_ROOT"
 command -v git >/dev/null 2>&1 || die "git is required on PATH"
 
-# abs DIR: absolute, symlink-resolved path of an existing directory. Callers
-# check the exit status; a failure is never silently folded into a path.
-abs() { (cd "$1" 2>/dev/null && pwd -P); }
+# abs DIR: absolute, symlink-resolved path of an existing directory, with `..`
+# resolved physically (cd -P), so "<symlink>/.." lands where the kernel puts it.
+# Callers check the exit status; a failure is never silently folded into a path.
+abs() { (cd -P "$1" 2>/dev/null && pwd -P); }
 
 # --- resolve and check paths, before anything else --------------------------------
 
@@ -138,6 +141,12 @@ RIG_COMMON="$(abs "$RIG_COMMON")" || die "cannot resolve the rig's git dir"
 git_rig() { git -C "$RIG_ROOT" "$@"; }
 
 # --- lock: one run per repository at a time -----------------------------------------
+# mkdir is the atomic acquire. A stale lock (owner pid dead or a zombie, or no
+# owner published for over two minutes) is reclaimed by RENAMING it to a
+# private name first: rename is atomic, so of two contenders that both saw the
+# same stale lock only one succeeds and only that one removes what it renamed;
+# the other's rename fails and it simply retries mkdir. Nothing ever removes a
+# lock in place, so a live lock cannot be deleted by a late contender.
 
 LOCK="$RIG_COMMON/worker-worktree.lock"
 LOCKED=0
@@ -146,6 +155,26 @@ release_lock() {
         rm -f "$LOCK/pid" 2>/dev/null || true
         rmdir "$LOCK" 2>/dev/null || true
         LOCKED=0
+    fi
+}
+
+lock_is_stale() {
+    owner="$(cat "$LOCK/pid" 2>/dev/null || true)"
+    if [ -n "$owner" ]; then
+        ! kill -0 "$owner" 2>/dev/null || owner_is_zombie "$owner"
+    else
+        # No owner published: a run died between mkdir and the pid write. Age it
+        # out rather than trusting the gap (a live run publishes within ms).
+        [ -n "$(find "$LOCK" -maxdepth 0 -mmin +2 2>/dev/null)" ]
+    fi
+}
+
+reclaim_stale_lock() {
+    claimed="$LOCK.stale.$$"
+    if mv "$LOCK" "$claimed" 2>/dev/null; then
+        warn "clearing stale lock $LOCK (owner pid ${owner:-none})"
+        rm -f "$claimed/pid" 2>/dev/null || true
+        rmdir "$claimed" 2>/dev/null || true
     fi
 }
 trap 'release_lock' EXIT
@@ -167,13 +196,8 @@ while :; do
         printf '%s\n' "$$" > "$LOCK/pid"
         break
     fi
-    owner="$(cat "$LOCK/pid" 2>/dev/null || true)"
-    # Dead owner: no such process, or a zombie its parent never reaped (kill -0
-    # still succeeds on a zombie; ps reports state Z).
-    if [ -n "$owner" ] && { ! kill -0 "$owner" 2>/dev/null || owner_is_zombie "$owner"; }; then
-        warn "clearing stale lock $LOCK left by pid $owner"
-        rm -f "$LOCK/pid" 2>/dev/null || true
-        rmdir "$LOCK" 2>/dev/null || true
+    if lock_is_stale; then
+        reclaim_stale_lock
         continue
     fi
     [ "$waited" -lt "$LOCK_WAIT" ] || die "another worker-worktree run (pid ${owner:-unknown}) has held $LOCK for ${LOCK_WAIT}s"
@@ -202,7 +226,9 @@ if [ -z "$BASE" ]; then
         warn "no $REMOTE/HEAD, $REMOTE/main or $REMOTE/master; new branches start at the rig root's HEAD"
     fi
 fi
-git_rig rev-parse --verify --quiet "$BASE^{commit}" >/dev/null || die "base ref does not resolve: $BASE"
+# Pin the base to a commit once, in the rig: a symbolic name such as HEAD would
+# otherwise be re-read inside the lane, where it means something else.
+BASE_SHA="$(git_rig rev-parse --verify --quiet "$BASE^{commit}")" || die "base ref does not resolve: $BASE"
 
 # --- helpers ------------------------------------------------------------------------------
 
@@ -262,40 +288,6 @@ move_aside() {
     warn "moved aside $1 -> $aside ($2); nothing was deleted"
 }
 
-# --- resolve what the work dir should have checked out --------------------------------------
-# MODE: local (check out TARGET), remote (track TARGET from the remote),
-# new (create TARGET from BASE), detached (detach at DETACH_AT).
-MODE=""
-TARGET=""
-DETACH_AT=""
-if [ -z "$BEAD" ]; then
-    MODE="detached"
-    DETACH_AT="$BASE"
-else
-    candidates="$(bead_branches)"
-    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
-    if [ "$count" -gt 1 ]; then
-        die "several branches name bead $BEAD; pass --bead with a unique id, or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
-    elif [ "$count" -eq 0 ]; then
-        MODE="new"
-        TARGET="$BEAD"
-    else
-        TARGET="$candidates"
-        if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
-            elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
-            if [ -n "$elsewhere" ]; then
-                MODE="detached"
-                DETACH_AT="$TARGET"
-                warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
-            else
-                MODE="local"
-            fi
-        else
-            MODE="remote"
-        fi
-    fi
-fi
-
 # --- classify the work dir ------------------------------------------------------------------
 IS_WORKTREE=0
 if [ -d "$WORKDIR" ]; then
@@ -310,13 +302,50 @@ if [ -d "$WORKDIR" ]; then
     fi
 fi
 
+# --- resolve what the work dir should have checked out --------------------------------------
+# Runs AFTER classification so a worktree just moved aside (which still holds
+# its branch) is seen as "checked out elsewhere" and the detached fallback
+# applies instead of a failing worktree add.
+# MODE: local (check out TARGET), remote (track TARGET from the remote),
+# new (create TARGET from BASE_SHA), detached (detach at DETACH_AT, a commit).
+MODE=""
+TARGET=""
+DETACH_AT=""
+if [ -z "$BEAD" ]; then
+    MODE="detached"
+    DETACH_AT="$BASE_SHA"
+else
+    candidates="$(bead_branches)"
+    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
+    if [ "$count" -gt 1 ]; then
+        die "several branches name bead $BEAD; pass --bead with a unique id, or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
+    elif [ "$count" -eq 0 ]; then
+        MODE="new"
+        TARGET="$BEAD"
+    else
+        TARGET="$candidates"
+        if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
+            elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
+            if [ -n "$elsewhere" ]; then
+                MODE="detached"
+                DETACH_AT="$(git_rig rev-parse --verify "refs/heads/$TARGET^{commit}")"
+                warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
+            else
+                MODE="local"
+            fi
+        else
+            MODE="remote"
+        fi
+    fi
+fi
+
 # --- act --------------------------------------------------------------------------------------
 add_worktree() {
     [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
     case "$MODE" in
         local)    git_rig worktree add --quiet "$WORKDIR" "$TARGET" ;;
         remote)   git_rig worktree add --quiet --track -b "$TARGET" "$WORKDIR" "$REMOTE/$TARGET" ;;
-        new)      git_rig worktree add --quiet -b "$TARGET" "$WORKDIR" "$BASE" ;;
+        new)      git_rig worktree add --quiet -b "$TARGET" "$WORKDIR" "$BASE_SHA" ;;
         detached) git_rig worktree add --quiet --detach "$WORKDIR" "$DETACH_AT" ;;
     esac
 }
@@ -328,7 +357,7 @@ switch_worktree() {
     case "$MODE" in
         local)    git -C "$WORKDIR" switch --quiet --no-overwrite-ignore "$TARGET" ;;
         remote)   git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" --track "$REMOTE/$TARGET" ;;
-        new)      git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" "$BASE" ;;
+        new)      git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" "$BASE_SHA" ;;
         detached) git -C "$WORKDIR" switch --quiet --no-overwrite-ignore --detach "$DETACH_AT" ;;
     esac
 }
@@ -338,8 +367,7 @@ if [ "$IS_WORKTREE" -eq 1 ]; then
     need_switch=1
     case "$MODE" in
         local)    [ "$current" != "$TARGET" ] || need_switch=0 ;;
-        detached) if [ "$current" = "HEAD" ] \
-                     && [ "$(git -C "$WORKDIR" rev-parse HEAD)" = "$(git_rig rev-parse "$DETACH_AT^{commit}")" ]; then
+        detached) if [ "$current" = "HEAD" ] && [ "$(git -C "$WORKDIR" rev-parse HEAD)" = "$DETACH_AT" ]; then
                       need_switch=0
                   fi ;;
     esac
@@ -360,7 +388,8 @@ is_our_worktree "$WORKDIR" || die "$WORKDIR is not a worktree of $RIG_ROOT after
 branch="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
 case "$MODE" in
     local|remote|new) [ "$branch" = "$TARGET" ] || die "$WORKDIR is on $branch, expected $TARGET" ;;
-    detached)         [ "$branch" = "HEAD" ] || die "$WORKDIR is on $branch, expected a detached HEAD" ;;
+    detached)         [ "$branch" = "HEAD" ] || die "$WORKDIR is on $branch, expected a detached HEAD"
+                      [ "$(git -C "$WORKDIR" rev-parse HEAD)" = "$DETACH_AT" ] || die "$WORKDIR is detached at $(git -C "$WORKDIR" rev-parse --short HEAD), expected $DETACH_AT" ;;
 esac
 [ "$branch" != "HEAD" ] || branch="detached"
 sha="$(git -C "$WORKDIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -21,18 +21,28 @@
 #
 # Contract:
 #   * The rig root's working tree is never touched: the script only reads
-#     refs, fetches, and registers worktrees from it.
+#     refs, fetches, and registers worktrees from it. A work dir that is the
+#     rig root, inside it, or an ancestor of it is refused before any change.
 #   * Nothing is deleted. A work dir that is not a worktree of this repository
 #     and is not empty is moved to <workdir>.aside-<utc stamp>; a worktree with
 #     tracked modifications is moved aside the same way before a fresh one
-#     replaces it. Untracked files (staged skills, hooks, node_modules) do not
-#     count as modifications and ride along on a branch switch.
+#     replaces it; a branch switch that would overwrite an ignored file
+#     (`git switch --no-overwrite-ignore`) moves the worktree aside instead.
+#     Untracked files (staged skills, hooks, node_modules) do not count as
+#     modifications and ride along on a branch switch. A worktree git refuses
+#     to move (locked) is left in place and the script fails.
 #   * Bead branch: exactly one branch (local or on the remote) whose name
-#     contains the bead id is reused. None: a new branch named <bead id> is
-#     created from --base. Several: fail closed and list them.
+#     contains the bead id as a whole token — `gp-abc1`, `fix/gp-abc1-x`, never
+#     `gp-abc10` — is reused. None: a new branch named <bead id> is created
+#     from --base. Several: fail closed and list them. If another session
+#     creates the branch first, this one falls back the same way it would have
+#     had the branch existed at the start (checkout, or detached when it is
+#     checked out elsewhere).
 #   * A bead branch already checked out in another worktree is not stolen: the
-#     work dir is left detached at that branch's tip and a WARN line names the
-#     other worktree.
+#     work dir is left detached at that branch's tip and a WARN line says so.
+#     Create your own branch in this work dir before committing.
+#   * No bead: the work dir is detached at --base, whatever branch it was on
+#     (the branch itself is kept; nothing is deleted).
 #   * Idempotent. Re-running on a work dir that is already on the right branch
 #     changes nothing (besides the fetch).
 #   * On success prints one line: WORKTREE <dir> <branch|detached> <head sha>.
@@ -63,7 +73,7 @@ while [ "$#" -gt 0 ]; do
         --remote) [ "$#" -ge 2 ] || die "--remote needs a value"; REMOTE="$2"; shift 2 ;;
         --remote=*) REMOTE="${1#--remote=}"; shift ;;
         --no-fetch) FETCH=0; shift ;;
-        -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -h|--help) sed -n '2,50p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *) die "unknown argument: $1" ;;
     esac
 done
@@ -73,12 +83,41 @@ done
 [ -d "$RIG_ROOT" ] || die "rig root is not a directory: $RIG_ROOT"
 command -v git >/dev/null 2>&1 || die "git is required on PATH"
 
-# Resolve to absolute, physical paths so worktree bookkeeping compares cleanly.
+# abs DIR: absolute, symlink-resolved path of an existing directory.
 abs() { (cd "$1" 2>/dev/null && pwd -P); }
+
+# canon PATH: the same for a path that need not exist yet — resolve the deepest
+# existing ancestor and re-append the rest, so a not-yet-created work dir is
+# compared on the real filesystem location it will occupy.
+canon() {
+    p="$1"
+    case "$p" in
+        /*) ;;
+        *) p="$PWD/$p" ;;
+    esac
+    rest=""
+    while [ ! -d "$p" ]; do
+        base="${p##*/}"
+        parent="${p%/*}"
+        [ -n "$parent" ] || parent="/"
+        [ "$parent" != "$p" ] || die "cannot resolve path: $1"
+        rest="/$base$rest"
+        p="$parent"
+    done
+    printf '%s%s\n' "$(abs "$p")" "$rest"
+}
+
 RIG_ROOT="$(abs "$RIG_ROOT")" || die "cannot enter rig root"
-case "$WORKDIR" in
-    /*) ;;
-    *) WORKDIR="$PWD/$WORKDIR" ;;
+WORKDIR="$(canon "$WORKDIR")"
+
+# Refuse before anything else: the rig root itself, anything inside it, and any
+# ancestor of it (moving an ancestor aside would move the rig).
+[ "$WORKDIR" != "$RIG_ROOT" ] || die "work dir is the rig root; give the agent a work_dir outside it"
+case "$WORKDIR/" in
+    "$RIG_ROOT"/*) die "work dir $WORKDIR is inside the rig root $RIG_ROOT" ;;
+esac
+case "$RIG_ROOT/" in
+    "$WORKDIR"/*) die "work dir $WORKDIR is an ancestor of the rig root $RIG_ROOT" ;;
 esac
 
 RIG_COMMON="$(git -C "$RIG_ROOT" rev-parse --git-common-dir 2>/dev/null)" \
@@ -88,16 +127,6 @@ case "$RIG_COMMON" in
     *) RIG_COMMON="$RIG_ROOT/$RIG_COMMON" ;;
 esac
 RIG_COMMON="$(abs "$RIG_COMMON")" || die "cannot resolve the rig's git dir"
-
-# The work dir must not be the rig root itself or sit inside its checkout.
-if [ -d "$WORKDIR" ]; then
-    WORKDIR_ABS="$(abs "$WORKDIR")"
-    [ "$WORKDIR_ABS" != "$RIG_ROOT" ] || die "work dir is the rig root; give the agent a work_dir outside it"
-    case "$WORKDIR_ABS/" in
-        "$RIG_ROOT"/*) die "work dir $WORKDIR_ABS is inside the rig root $RIG_ROOT" ;;
-    esac
-    WORKDIR="$WORKDIR_ABS"
-fi
 
 git_rig() { git -C "$RIG_ROOT" "$@"; }
 
@@ -121,153 +150,176 @@ if [ -z "$BASE" ]; then
 fi
 git_rig rev-parse --verify --quiet "$BASE^{commit}" >/dev/null || die "base ref does not resolve: $BASE"
 
-# --- bead branch resolution -------------------------------------------------
-# TARGET_LOCAL: local branch to check out.  TARGET_REMOTE: remote branch to track
-# when no local branch exists.  TARGET_NEW: branch to create from BASE.
-TARGET_LOCAL=""
-TARGET_REMOTE=""
-TARGET_NEW=""
-if [ -n "$BEAD" ]; then
-    candidates="$(
-        {
-            git_rig for-each-ref --format='%(refname:short)' refs/heads
-            git_rig for-each-ref --format='%(refname:short)' "refs/remotes/$REMOTE" \
-                | grep -v "^$REMOTE/HEAD\$" | sed "s|^$REMOTE/||"
-        } | grep -F -- "$BEAD" | sort -u
-    )" || true
-    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
-    if [ "$count" -gt 1 ]; then
-        die "several branches name bead $BEAD; pass --bead with a unique id or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
-    elif [ "$count" -eq 1 ]; then
-        if git_rig show-ref --verify --quiet "refs/heads/$candidates"; then
-            TARGET_LOCAL="$candidates"
-        else
-            TARGET_REMOTE="$candidates"
-        fi
-    else
-        TARGET_NEW="$BEAD"
-    fi
-fi
+# --- helpers -------------------------------------------------------------------
 
-# Where (if anywhere) is a local branch checked out?  Prints the worktree path.
+# bead_branches: every branch name (local, and remote with the remote prefix
+# stripped) containing BEAD as a whole token, one per line, de-duplicated.
+bead_branches() {
+    # Escape the id for an ERE, then require a non-alphanumeric boundary (or
+    # the string edge) on both sides so gp-abc1 never matches gp-abc10.
+    id_re="$(printf '%s' "$BEAD" | sed 's/[][\\.^$*+?(){}|/]/\\&/g')"
+    {
+        git_rig for-each-ref --format='%(refname:short)' refs/heads
+        git_rig for-each-ref --format='%(refname:short)' "refs/remotes/$REMOTE" \
+            | grep -v "^$REMOTE/HEAD\$" | sed "s|^$REMOTE/||"
+    } | grep -E -- "(^|[^A-Za-z0-9])${id_re}([^A-Za-z0-9]|\$)" | sort -u || true
+}
+
+# checked_out_at BRANCH: the worktree path holding BRANCH, if any. Paths may
+# contain spaces, so keep the whole line after the "worktree " key.
 checked_out_at() {
     git_rig worktree list --porcelain | awk -v want="refs/heads/$1" '
-        $1 == "worktree" { wt = $2 }
+        /^worktree / { wt = $0; sub(/^worktree /, "", wt) }
         $1 == "branch" && $2 == want { print wt }
     '
 }
 
+is_our_worktree() {
+    [ -e "$1/.git" ] || return 1
+    c="$(git -C "$1" rev-parse --git-common-dir 2>/dev/null || true)"
+    [ -n "$c" ] || return 1
+    case "$c" in
+        /*) ;;
+        *) c="$1/$c" ;;
+    esac
+    [ -d "$c" ] && [ "$(abs "$c")" = "$RIG_COMMON" ]
+}
+
+# move_aside DIR REASON: relocate DIR out of the way without deleting anything.
+# A registered worktree goes through `git worktree move` so its registration
+# follows it; if git refuses (locked, or otherwise), fail closed rather than
+# mv a registered worktree out from under git.
 move_aside() {
     stamp="$(date -u +%Y%m%dT%H%M%SZ)"
     aside="$1.aside-$stamp"
     n=0
     while [ -e "$aside" ]; do n=$((n + 1)); aside="$1.aside-$stamp-$n"; done
-    if git -C "$1" rev-parse --git-common-dir >/dev/null 2>&1 \
-        && [ "$(abs "$(git -C "$1" rev-parse --git-common-dir)")" = "$RIG_COMMON" ]; then
-        git_rig worktree move "$1" "$aside" >/dev/null 2>&1 || mv "$1" "$aside"
+    if is_our_worktree "$1"; then
+        if ! out="$(git_rig worktree move "$1" "$aside" 2>&1)"; then
+            die "git refused to move the worktree $1 aside ($2): $out"
+        fi
     else
         mv "$1" "$aside"
     fi
     warn "moved aside $1 -> $aside ($2); nothing was deleted"
 }
 
-# --- classify the work dir ----------------------------------------------------
-IS_WORKTREE=0
-if [ -d "$WORKDIR" ] && [ -e "$WORKDIR/.git" ]; then
-    wd_common="$(git -C "$WORKDIR" rev-parse --git-common-dir 2>/dev/null || true)"
-    case "$wd_common" in
-        "") ;;
-        /*) ;;
-        *) wd_common="$WORKDIR/$wd_common" ;;
-    esac
-    if [ -n "$wd_common" ] && [ -d "$wd_common" ] && [ "$(abs "$wd_common")" = "$RIG_COMMON" ]; then
-        IS_WORKTREE=1
-    fi
-fi
-
-if [ "$IS_WORKTREE" -eq 0 ] && [ -d "$WORKDIR" ]; then
-    if [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
-        move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
-    fi
-fi
-
-if [ "$IS_WORKTREE" -eq 1 ]; then
-    if [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
-        move_aside "$WORKDIR" "tracked modifications present"
-        IS_WORKTREE=0
-    fi
-fi
-
-# --- act ----------------------------------------------------------------------
-add_worktree() {
-    # $1 = mode: local|remote|new|detached
-    [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
-    case "$1" in
-        local)    git_rig worktree add --quiet "$WORKDIR" "$TARGET_LOCAL" ;;
-        remote)   git_rig worktree add --quiet --track -b "$TARGET_REMOTE" "$WORKDIR" "$REMOTE/$TARGET_REMOTE" ;;
-        new)      git_rig worktree add --quiet -b "$TARGET_NEW" "$WORKDIR" "$BASE" ;;
-        detached) git_rig worktree add --quiet --detach "$WORKDIR" "$2" ;;
-    esac
-}
-
-switch_worktree() {
-    # $1 = mode as above; the work dir is a clean worktree already.
-    case "$1" in
-        local)    git -C "$WORKDIR" switch --quiet "$TARGET_LOCAL" ;;
-        remote)   git -C "$WORKDIR" switch --quiet -c "$TARGET_REMOTE" --track "$REMOTE/$TARGET_REMOTE" ;;
-        new)      git -C "$WORKDIR" switch --quiet -c "$TARGET_NEW" "$BASE" ;;
-        detached) git -C "$WORKDIR" switch --quiet --detach "$2" ;;
-    esac
-}
-
-MODE=""
-DETACH_AT=""
-if [ -n "$TARGET_LOCAL" ]; then
-    elsewhere="$(checked_out_at "$TARGET_LOCAL" | grep -v -x -F -- "$WORKDIR" || true)"
-    if [ -n "$elsewhere" ]; then
+# --- bead branch resolution -----------------------------------------------------
+# MODE: local (check out TARGET), remote (track TARGET from the remote),
+# new (create TARGET from BASE), detached (detach at DETACH_AT).
+resolve_mode() {
+    MODE=""
+    TARGET=""
+    DETACH_AT=""
+    if [ -z "$BEAD" ]; then
         MODE="detached"
-        DETACH_AT="$TARGET_LOCAL"
-        warn "branch $TARGET_LOCAL is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch before committing, or work in that worktree."
-    else
-        MODE="local"
+        DETACH_AT="$BASE"
+        return
     fi
-elif [ -n "$TARGET_REMOTE" ]; then
-    MODE="remote"
-elif [ -n "$TARGET_NEW" ]; then
-    MODE="new"
-else
-    MODE="detached"
-    DETACH_AT="$BASE"
+    candidates="$(bead_branches)"
+    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
+    if [ "$count" -gt 1 ]; then
+        die "several branches name bead $BEAD; pass --bead with a unique id, or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
+    fi
+    if [ "$count" -eq 0 ]; then
+        MODE="new"
+        TARGET="$BEAD"
+        return
+    fi
+    TARGET="$candidates"
+    if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
+        elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
+        if [ -n "$elsewhere" ]; then
+            MODE="detached"
+            DETACH_AT="$TARGET"
+            warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
+        else
+            MODE="local"
+        fi
+    else
+        MODE="remote"
+    fi
+}
+
+# --- classify the work dir --------------------------------------------------------
+IS_WORKTREE=0
+if [ -d "$WORKDIR" ] && is_our_worktree "$WORKDIR"; then
+    IS_WORKTREE=1
 fi
+
+if [ "$IS_WORKTREE" -eq 0 ] && [ -d "$WORKDIR" ] && [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
+    move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
+fi
+
+if [ "$IS_WORKTREE" -eq 1 ] && [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+    move_aside "$WORKDIR" "tracked modifications present"
+    IS_WORKTREE=0
+fi
+
+# --- act ----------------------------------------------------------------------------
+add_worktree() {
+    [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
+    case "$MODE" in
+        local)    git_rig worktree add --quiet "$WORKDIR" "$TARGET" ;;
+        remote)   git_rig worktree add --quiet --track -b "$TARGET" "$WORKDIR" "$REMOTE/$TARGET" ;;
+        new)      git_rig worktree add --quiet -b "$TARGET" "$WORKDIR" "$BASE" ;;
+        detached) git_rig worktree add --quiet --detach "$WORKDIR" "$DETACH_AT" ;;
+    esac
+}
+
+# switch_worktree: change what a clean worktree has checked out. Never
+# overwrite an ignored file the target tracks; on any refusal the caller moves
+# the worktree aside and adds a fresh one.
+switch_worktree() {
+    case "$MODE" in
+        local)    git -C "$WORKDIR" switch --quiet --no-overwrite-ignore "$TARGET" ;;
+        remote)   git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" --track "$REMOTE/$TARGET" ;;
+        new)      git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" "$BASE" ;;
+        detached) git -C "$WORKDIR" switch --quiet --no-overwrite-ignore --detach "$DETACH_AT" ;;
+    esac
+}
+
+resolve_mode
+
+# A branch this run meant to create may have been created by a concurrent run
+# between resolution and the git call; re-resolving turns that into the
+# checkout-or-detached path the contract promises instead of a failure.
+attempt() {
+    # $1 = add|switch
+    tries=0
+    while :; do
+        tries=$((tries + 1))
+        if [ "$1" = add ]; then
+            if out="$(add_worktree 2>&1)"; then return 0; fi
+        else
+            if out="$(switch_worktree 2>&1)"; then return 0; fi
+        fi
+        if [ "$MODE" = "new" ] && [ "$tries" -lt 3 ] && git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
+            log "branch $TARGET appeared while preparing $WORKDIR; re-resolving"
+            resolve_mode
+            continue
+        fi
+        printf '%s\n' "$out" >&2
+        return 1
+    done
+}
 
 if [ "$IS_WORKTREE" -eq 1 ]; then
     current="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+    need_switch=1
     case "$MODE" in
-        local)  [ "$current" = "$TARGET_LOCAL" ] || switch_worktree local ;;
-        remote) switch_worktree remote ;;
-        new)    if git_rig show-ref --verify --quiet "refs/heads/$TARGET_NEW"; then
-                    # Created by a concurrent run between resolution and now.
-                    TARGET_LOCAL="$TARGET_NEW"; switch_worktree local
-                else
-                    switch_worktree new
-                fi ;;
-        detached)
-                if [ -n "$BEAD" ]; then
-                    switch_worktree detached "$DETACH_AT"
-                elif [ "$current" = "HEAD" ]; then
-                    # No bead and already detached: refresh to the base tip.
-                    switch_worktree detached "$DETACH_AT"
-                fi
-                # No bead and on a branch: leave the lane where a previous
-                # session put it; the worker owns that branch.
-                ;;
+        local)    [ "$current" != "$TARGET" ] || need_switch=0 ;;
+        detached) if [ "$current" = "HEAD" ] \
+                     && [ "$(git -C "$WORKDIR" rev-parse HEAD)" = "$(git_rig rev-parse "$DETACH_AT^{commit}")" ]; then
+                      need_switch=0
+                  fi ;;
     esac
-else
-    if [ "$MODE" = "detached" ]; then
-        add_worktree detached "$DETACH_AT"
-    else
-        add_worktree "$MODE"
+    if [ "$need_switch" -eq 1 ] && ! attempt switch; then
+        move_aside "$WORKDIR" "branch switch refused (ignored files in the way, or git error above)"
+        attempt add || die "could not prepare $WORKDIR after moving the previous worktree aside"
     fi
+else
+    attempt add || die "could not create the worktree at $WORKDIR"
 fi
 
 WORKDIR="$(abs "$WORKDIR")"

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -24,10 +24,11 @@
 #   * One path, serialized. Every run on a repository takes the lock
 #     <git common dir>/worker-worktree.lock (mkdir) before it reads or changes
 #     anything and releases it on exit. A stale lock (owner dead or a zombie, or
-#     no owner published for two minutes) is reclaimed by an atomic rename, so
-#     two contenders cannot both clear it and a live lock is never removed. Two
-#     sessions preparing lanes at once therefore cannot race on branch
-#     creation, on the same lane, or on the aside destination.
+#     no owner published for two minutes) is cleared only under a second,
+#     atomic reclaim lock and only after re-checking it is still the same stale
+#     lock, so two contenders cannot both clear it and a live lock is never
+#     removed. Two sessions preparing lanes at once therefore cannot race on
+#     branch creation, on the same lane, or on the aside destination.
 #   * The work dir is resolved on the real filesystem: it must exist, or its
 #     parent must exist and its last component must be a plain name (no `.`,
 #     `..`, or deeper missing levels). Symlinks resolve. The rig root itself,
@@ -52,9 +53,9 @@
 #     Create your own branch in this work dir before committing.
 #   * No bead: the work dir is detached at --base, whatever branch it was on
 #     (the branch itself is kept; nothing is deleted).
-#   * Idempotent. Re-running on a work dir that is already on the right branch
-#     changes nothing (besides the fetch). The result is verified before the
-#     script reports success.
+#   * Idempotent for a clean work dir already on the requested branch (or
+#     detached at the requested commit): re-running changes nothing besides
+#     the fetch. The result is verified before the script reports success.
 #   * On success prints one line: WORKTREE <dir> <branch|detached> <head sha>.
 
 set -eu
@@ -142,11 +143,14 @@ git_rig() { git -C "$RIG_ROOT" "$@"; }
 
 # --- lock: one run per repository at a time -----------------------------------------
 # mkdir is the atomic acquire. A stale lock (owner pid dead or a zombie, or no
-# owner published for over two minutes) is reclaimed by RENAMING it to a
-# private name first: rename is atomic, so of two contenders that both saw the
-# same stale lock only one succeeds and only that one removes what it renamed;
-# the other's rename fails and it simply retries mkdir. Nothing ever removes a
-# lock in place, so a live lock cannot be deleted by a late contender.
+# owner published for over two minutes) is cleared only by the contender that
+# wins a second mkdir, the reclaim lock, and only after it re-reads the lock
+# and finds it still stale: a contender that observed the stale lock, lost the
+# race, and arrives late finds a live owner (or no lock) under the reclaim lock
+# and does nothing. So a live lock is never removed by a late contender. A
+# reclaim lock left by a crash ages out after two minutes. Test-only pauses
+# (WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM / _AFTER_ACQUIRE, seconds) exist so
+# the two-contender interleavings can be exercised deterministically.
 
 LOCK="$RIG_COMMON/worker-worktree.lock"
 LOCKED=0
@@ -158,24 +162,41 @@ release_lock() {
     fi
 }
 
+# lock_is_stale: the lock at $LOCK has a dead/zombie owner, or no owner for
+# over two minutes (a run died between mkdir and the pid write; a live run
+# publishes within milliseconds). Sets `owner`.
 lock_is_stale() {
+    [ -d "$LOCK" ] || return 1
     owner="$(cat "$LOCK/pid" 2>/dev/null || true)"
     if [ -n "$owner" ]; then
         ! kill -0 "$owner" 2>/dev/null || owner_is_zombie "$owner"
     else
-        # No owner published: a run died between mkdir and the pid write. Age it
-        # out rather than trusting the gap (a live run publishes within ms).
         [ -n "$(find "$LOCK" -maxdepth 0 -mmin +2 2>/dev/null)" ]
     fi
 }
 
+RECLAIM="$LOCK.reclaim"
+# reclaim_stale_lock: clear $LOCK if, under the reclaim lock, it is still stale.
+# Returns 0 when something was cleared, 1 otherwise (lost the reclaim race, the
+# lock turned out live or gone, or the reclaim lock itself is stuck).
 reclaim_stale_lock() {
-    claimed="$LOCK.stale.$$"
-    if mv "$LOCK" "$claimed" 2>/dev/null; then
-        warn "clearing stale lock $LOCK (owner pid ${owner:-none})"
-        rm -f "$claimed/pid" 2>/dev/null || true
-        rmdir "$claimed" 2>/dev/null || true
+    if ! mkdir "$RECLAIM" 2>/dev/null; then
+        # Someone else is reclaiming; a reclaim lock older than two minutes is a
+        # crash residue and is removed so the next pass can proceed.
+        if [ -n "$(find "$RECLAIM" -maxdepth 0 -mmin +2 2>/dev/null)" ]; then
+            rmdir "$RECLAIM" 2>/dev/null || true
+        fi
+        return 1
     fi
+    [ -z "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
+    cleared=1
+    if lock_is_stale; then
+        warn "clearing stale lock $LOCK (owner pid ${owner:-none})"
+        rm -f "$LOCK/pid" 2>/dev/null || true
+        rmdir "$LOCK" 2>/dev/null && cleared=0
+    fi
+    rmdir "$RECLAIM" 2>/dev/null || true
+    return "$cleared"
 }
 trap 'release_lock' EXIT
 trap 'release_lock; exit 129' HUP
@@ -194,12 +215,13 @@ while :; do
     if mkdir "$LOCK" 2>/dev/null; then
         LOCKED=1
         printf '%s\n' "$$" > "$LOCK/pid"
+        [ -z "${WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE"
         break
     fi
-    if lock_is_stale; then
-        reclaim_stale_lock
+    if lock_is_stale && reclaim_stale_lock; then
         continue
     fi
+    # Live lock, or a reclaim that did not clear anything: bounded wait.
     [ "$waited" -lt "$LOCK_WAIT" ] || die "another worker-worktree run (pid ${owner:-unknown}) has held $LOCK for ${LOCK_WAIT}s"
     [ "$waited" -gt 0 ] || log "waiting for another run on this repository (pid ${owner:-unknown})"
     sleep 1
@@ -241,7 +263,10 @@ bead_branches() {
     {
         git_rig for-each-ref --format='%(refname:short)' refs/heads
         git_rig for-each-ref --format='%(refname:short)' "refs/remotes/$REMOTE" \
-            | grep -v "^$REMOTE/HEAD\$" | sed "s|^$REMOTE/||"
+            | while IFS= read -r ref; do
+                [ "$ref" != "$REMOTE/HEAD" ] || continue
+                printf '%s\n' "${ref#"$REMOTE/"}"
+            done
     } | grep -E -- "(^|[^A-Za-z0-9])${id_re}([^A-Za-z0-9]|\$)" | sort -u || true
 }
 

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -222,7 +222,10 @@ while :; do
         break
     fi
     if lock_is_stale; then
-        [ -z "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ] || sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
+        if [ -n "${WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM:-}" ]; then
+            log "TEST pausing before reclaim"
+            sleep "$WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM"
+        fi
         if reclaim_stale_lock; then
             continue
         fi

--- a/gascity/assets/scripts/worker-worktree.sh
+++ b/gascity/assets/scripts/worker-worktree.sh
@@ -18,33 +18,41 @@
 #   --base REF       start point for a new branch (default <remote>/HEAD, else <remote>/main)
 #   --remote NAME    remote to fetch and match branches on (default origin)
 #   --no-fetch       do not fetch before resolving refs
+#   WORKER_WORKTREE_LOCK_WAIT  seconds to wait for another run on the same repository (default 120)
 #
 # Contract:
+#   * One path, serialized. Every run on a repository takes the lock
+#     <git common dir>/worker-worktree.lock before it reads or changes anything
+#     and releases it on exit; a lock whose owning pid is gone is cleared. So
+#     two sessions preparing lanes at once cannot race on branch creation, on
+#     the same lane, or on the aside destination.
+#   * The work dir is resolved on the real filesystem: it must exist, or its
+#     parent must exist and its last component must be a plain name (no `.`,
+#     `..`, or deeper missing levels). Symlinks resolve. The rig root itself,
+#     anything inside it, and any ancestor of it are refused before any change.
 #   * The rig root's working tree is never touched: the script only reads
-#     refs, fetches, and registers worktrees from it. A work dir that is the
-#     rig root, inside it, or an ancestor of it is refused before any change.
-#   * Nothing is deleted. A work dir that is not a worktree of this repository
-#     and is not empty is moved to <workdir>.aside-<utc stamp>; a worktree with
-#     tracked modifications is moved aside the same way before a fresh one
-#     replaces it; a branch switch that would overwrite an ignored file
-#     (`git switch --no-overwrite-ignore`) moves the worktree aside instead.
+#     refs, fetches, and registers worktrees from it.
+#   * Nothing is deleted. A non-empty work dir that is not a git checkout is
+#     moved to <workdir>.aside-<utc stamp>; a worktree of this repository with
+#     tracked modifications is moved aside the same way (through `git worktree
+#     move`, so registration follows; if git refuses, e.g. locked, the script
+#     fails in place); a branch switch that would overwrite an ignored file
+#     (`git switch --no-overwrite-ignore`) moves the worktree aside instead. A
+#     checkout of ANOTHER repository at the work dir is refused, not moved.
 #     Untracked files (staged skills, hooks, node_modules) do not count as
-#     modifications and ride along on a branch switch. A worktree git refuses
-#     to move (locked) is left in place and the script fails.
+#     modifications and ride along on a branch switch.
 #   * Bead branch: exactly one branch (local or on the remote) whose name
 #     contains the bead id as a whole token — `gp-abc1`, `fix/gp-abc1-x`, never
 #     `gp-abc10` — is reused. None: a new branch named <bead id> is created
-#     from --base. Several: fail closed and list them. If another session
-#     creates the branch first, this one falls back the same way it would have
-#     had the branch existed at the start (checkout, or detached when it is
-#     checked out elsewhere).
+#     from --base. Several: fail closed and list them.
 #   * A bead branch already checked out in another worktree is not stolen: the
 #     work dir is left detached at that branch's tip and a WARN line says so.
 #     Create your own branch in this work dir before committing.
 #   * No bead: the work dir is detached at --base, whatever branch it was on
 #     (the branch itself is kept; nothing is deleted).
 #   * Idempotent. Re-running on a work dir that is already on the right branch
-#     changes nothing (besides the fetch).
+#     changes nothing (besides the fetch). The result is verified before the
+#     script reports success.
 #   * On success prints one line: WORKTREE <dir> <branch|detached> <head sha>.
 
 set -eu
@@ -59,6 +67,7 @@ BEAD="${GC_TRIGGER_BEAD_ID:-}"
 BASE=""
 REMOTE="origin"
 FETCH=1
+LOCK_WAIT="${WORKER_WORKTREE_LOCK_WAIT:-120}"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -73,7 +82,7 @@ while [ "$#" -gt 0 ]; do
         --remote) [ "$#" -ge 2 ] || die "--remote needs a value"; REMOTE="$2"; shift 2 ;;
         --remote=*) REMOTE="${1#--remote=}"; shift ;;
         --no-fetch) FETCH=0; shift ;;
-        -h|--help) sed -n '2,50p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -h|--help) sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *) die "unknown argument: $1" ;;
     esac
 done
@@ -83,35 +92,33 @@ done
 [ -d "$RIG_ROOT" ] || die "rig root is not a directory: $RIG_ROOT"
 command -v git >/dev/null 2>&1 || die "git is required on PATH"
 
-# abs DIR: absolute, symlink-resolved path of an existing directory.
+# abs DIR: absolute, symlink-resolved path of an existing directory. Callers
+# check the exit status; a failure is never silently folded into a path.
 abs() { (cd "$1" 2>/dev/null && pwd -P); }
 
-# canon PATH: the same for a path that need not exist yet — resolve the deepest
-# existing ancestor and re-append the rest, so a not-yet-created work dir is
-# compared on the real filesystem location it will occupy.
-canon() {
-    p="$1"
-    case "$p" in
-        /*) ;;
-        *) p="$PWD/$p" ;;
+# --- resolve and check paths, before anything else --------------------------------
+
+RIG_ROOT="$(abs "$RIG_ROOT")" || die "cannot enter rig root: $RIG_ROOT"
+
+case "$WORKDIR" in
+    /*) ;;
+    *) WORKDIR="$PWD/$WORKDIR" ;;
+esac
+while [ "${WORKDIR%/}" != "$WORKDIR" ] && [ "$WORKDIR" != "/" ]; do WORKDIR="${WORKDIR%/}"; done
+if [ -d "$WORKDIR" ]; then
+    WORKDIR="$(abs "$WORKDIR")" || die "cannot enter work dir: $WORKDIR"
+else
+    leaf="${WORKDIR##*/}"
+    parent="${WORKDIR%/*}"
+    [ -n "$parent" ] || parent="/"
+    case "$leaf" in
+        ""|.|..) die "work dir must end in a plain directory name: $WORKDIR" ;;
     esac
-    rest=""
-    while [ ! -d "$p" ]; do
-        base="${p##*/}"
-        parent="${p%/*}"
-        [ -n "$parent" ] || parent="/"
-        [ "$parent" != "$p" ] || die "cannot resolve path: $1"
-        rest="/$base$rest"
-        p="$parent"
-    done
-    printf '%s%s\n' "$(abs "$p")" "$rest"
-}
+    [ -d "$parent" ] || die "parent of work dir does not exist: $parent (gc creates work_dir before pre_start; create the parent first)"
+    parent="$(abs "$parent")" || die "cannot enter parent of work dir: $parent"
+    WORKDIR="$parent/$leaf"
+fi
 
-RIG_ROOT="$(abs "$RIG_ROOT")" || die "cannot enter rig root"
-WORKDIR="$(canon "$WORKDIR")"
-
-# Refuse before anything else: the rig root itself, anything inside it, and any
-# ancestor of it (moving an ancestor aside would move the rig).
 [ "$WORKDIR" != "$RIG_ROOT" ] || die "work dir is the rig root; give the agent a work_dir outside it"
 case "$WORKDIR/" in
     "$RIG_ROOT"/*) die "work dir $WORKDIR is inside the rig root $RIG_ROOT" ;;
@@ -129,6 +136,53 @@ esac
 RIG_COMMON="$(abs "$RIG_COMMON")" || die "cannot resolve the rig's git dir"
 
 git_rig() { git -C "$RIG_ROOT" "$@"; }
+
+# --- lock: one run per repository at a time -----------------------------------------
+
+LOCK="$RIG_COMMON/worker-worktree.lock"
+LOCKED=0
+release_lock() {
+    if [ "$LOCKED" -eq 1 ]; then
+        rm -f "$LOCK/pid" 2>/dev/null || true
+        rmdir "$LOCK" 2>/dev/null || true
+        LOCKED=0
+    fi
+}
+trap 'release_lock' EXIT
+trap 'release_lock; exit 129' HUP
+trap 'release_lock; exit 130' INT
+trap 'release_lock; exit 143' TERM
+
+owner_is_zombie() {
+    case "$(ps -o stat= -p "$1" 2>/dev/null | tr -d ' ')" in
+        Z*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+waited=0
+while :; do
+    if mkdir "$LOCK" 2>/dev/null; then
+        LOCKED=1
+        printf '%s\n' "$$" > "$LOCK/pid"
+        break
+    fi
+    owner="$(cat "$LOCK/pid" 2>/dev/null || true)"
+    # Dead owner: no such process, or a zombie its parent never reaped (kill -0
+    # still succeeds on a zombie; ps reports state Z).
+    if [ -n "$owner" ] && { ! kill -0 "$owner" 2>/dev/null || owner_is_zombie "$owner"; }; then
+        warn "clearing stale lock $LOCK left by pid $owner"
+        rm -f "$LOCK/pid" 2>/dev/null || true
+        rmdir "$LOCK" 2>/dev/null || true
+        continue
+    fi
+    [ "$waited" -lt "$LOCK_WAIT" ] || die "another worker-worktree run (pid ${owner:-unknown}) has held $LOCK for ${LOCK_WAIT}s"
+    [ "$waited" -gt 0 ] || log "waiting for another run on this repository (pid ${owner:-unknown})"
+    sleep 1
+    waited=$((waited + 1))
+done
+
+# --- refs -------------------------------------------------------------------------------
 
 if [ "$FETCH" -eq 1 ]; then
     if ! git_rig fetch --quiet --prune "$REMOTE" 2>/dev/null; then
@@ -150,7 +204,7 @@ if [ -z "$BASE" ]; then
 fi
 git_rig rev-parse --verify --quiet "$BASE^{commit}" >/dev/null || die "base ref does not resolve: $BASE"
 
-# --- helpers -------------------------------------------------------------------
+# --- helpers ------------------------------------------------------------------------------
 
 # bead_branches: every branch name (local, and remote with the remote prefix
 # stripped) containing BEAD as a whole token, one per line, de-duplicated.
@@ -174,21 +228,23 @@ checked_out_at() {
     '
 }
 
+# is_our_worktree DIR: DIR is a git checkout whose common dir is this rig's.
 is_our_worktree() {
     [ -e "$1/.git" ] || return 1
-    c="$(git -C "$1" rev-parse --git-common-dir 2>/dev/null || true)"
-    [ -n "$c" ] || return 1
+    c="$(git -C "$1" rev-parse --git-common-dir 2>/dev/null)" || return 1
     case "$c" in
         /*) ;;
         *) c="$1/$c" ;;
     esac
-    [ -d "$c" ] && [ "$(abs "$c")" = "$RIG_COMMON" ]
+    c="$(abs "$c")" || return 1
+    [ "$c" = "$RIG_COMMON" ]
 }
 
 # move_aside DIR REASON: relocate DIR out of the way without deleting anything.
-# A registered worktree goes through `git worktree move` so its registration
-# follows it; if git refuses (locked, or otherwise), fail closed rather than
-# mv a registered worktree out from under git.
+# A worktree of this repository goes through `git worktree move` so its
+# registration follows it; if git refuses (locked, or otherwise), fail closed.
+# Anything else that is a git checkout belongs to another repository and is
+# refused. Plain content is moved with mv.
 move_aside() {
     stamp="$(date -u +%Y%m%dT%H%M%SZ)"
     aside="$1.aside-$stamp"
@@ -198,65 +254,63 @@ move_aside() {
         if ! out="$(git_rig worktree move "$1" "$aside" 2>&1)"; then
             die "git refused to move the worktree $1 aside ($2): $out"
         fi
+    elif [ -e "$1/.git" ]; then
+        die "$1 is a git checkout of another repository; refusing to move or replace it ($2)"
     else
         mv "$1" "$aside"
     fi
     warn "moved aside $1 -> $aside ($2); nothing was deleted"
 }
 
-# --- bead branch resolution -----------------------------------------------------
+# --- resolve what the work dir should have checked out --------------------------------------
 # MODE: local (check out TARGET), remote (track TARGET from the remote),
 # new (create TARGET from BASE), detached (detach at DETACH_AT).
-resolve_mode() {
-    MODE=""
-    TARGET=""
-    DETACH_AT=""
-    if [ -z "$BEAD" ]; then
-        MODE="detached"
-        DETACH_AT="$BASE"
-        return
-    fi
+MODE=""
+TARGET=""
+DETACH_AT=""
+if [ -z "$BEAD" ]; then
+    MODE="detached"
+    DETACH_AT="$BASE"
+else
     candidates="$(bead_branches)"
     count="$(printf '%s\n' "$candidates" | grep -c . || true)"
     if [ "$count" -gt 1 ]; then
         die "several branches name bead $BEAD; pass --bead with a unique id, or --base and no bead: $(printf '%s\n' "$candidates" | tr '\n' ' ')"
-    fi
-    if [ "$count" -eq 0 ]; then
+    elif [ "$count" -eq 0 ]; then
         MODE="new"
         TARGET="$BEAD"
-        return
-    fi
-    TARGET="$candidates"
-    if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
-        elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
-        if [ -n "$elsewhere" ]; then
-            MODE="detached"
-            DETACH_AT="$TARGET"
-            warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
-        else
-            MODE="local"
-        fi
     else
-        MODE="remote"
+        TARGET="$candidates"
+        if git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
+            elsewhere="$(checked_out_at "$TARGET" | grep -v -x -F -- "$WORKDIR" || true)"
+            if [ -n "$elsewhere" ]; then
+                MODE="detached"
+                DETACH_AT="$TARGET"
+                warn "branch $TARGET is checked out at $elsewhere; leaving $WORKDIR detached at its tip. Create your own branch in this work dir before committing."
+            else
+                MODE="local"
+            fi
+        else
+            MODE="remote"
+        fi
     fi
-}
+fi
 
-# --- classify the work dir --------------------------------------------------------
+# --- classify the work dir ------------------------------------------------------------------
 IS_WORKTREE=0
-if [ -d "$WORKDIR" ] && is_our_worktree "$WORKDIR"; then
-    IS_WORKTREE=1
+if [ -d "$WORKDIR" ]; then
+    if is_our_worktree "$WORKDIR"; then
+        IS_WORKTREE=1
+        if [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+            move_aside "$WORKDIR" "tracked modifications present"
+            IS_WORKTREE=0
+        fi
+    elif [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
+        move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
+    fi
 fi
 
-if [ "$IS_WORKTREE" -eq 0 ] && [ -d "$WORKDIR" ] && [ -n "$(ls -A "$WORKDIR" 2>/dev/null)" ]; then
-    move_aside "$WORKDIR" "not a worktree of $RIG_ROOT"
-fi
-
-if [ "$IS_WORKTREE" -eq 1 ] && [ -n "$(git -C "$WORKDIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
-    move_aside "$WORKDIR" "tracked modifications present"
-    IS_WORKTREE=0
-fi
-
-# --- act ----------------------------------------------------------------------------
+# --- act --------------------------------------------------------------------------------------
 add_worktree() {
     [ -d "$WORKDIR" ] || mkdir -p "$WORKDIR"
     case "$MODE" in
@@ -267,7 +321,7 @@ add_worktree() {
     esac
 }
 
-# switch_worktree: change what a clean worktree has checked out. Never
+# switch_worktree: change what a clean worktree of ours has checked out. Never
 # overwrite an ignored file the target tracks; on any refusal the caller moves
 # the worktree aside and adds a fresh one.
 switch_worktree() {
@@ -277,31 +331,6 @@ switch_worktree() {
         new)      git -C "$WORKDIR" switch --quiet --no-overwrite-ignore -c "$TARGET" "$BASE" ;;
         detached) git -C "$WORKDIR" switch --quiet --no-overwrite-ignore --detach "$DETACH_AT" ;;
     esac
-}
-
-resolve_mode
-
-# A branch this run meant to create may have been created by a concurrent run
-# between resolution and the git call; re-resolving turns that into the
-# checkout-or-detached path the contract promises instead of a failure.
-attempt() {
-    # $1 = add|switch
-    tries=0
-    while :; do
-        tries=$((tries + 1))
-        if [ "$1" = add ]; then
-            if out="$(add_worktree 2>&1)"; then return 0; fi
-        else
-            if out="$(switch_worktree 2>&1)"; then return 0; fi
-        fi
-        if [ "$MODE" = "new" ] && [ "$tries" -lt 3 ] && git_rig show-ref --verify --quiet "refs/heads/$TARGET"; then
-            log "branch $TARGET appeared while preparing $WORKDIR; re-resolving"
-            resolve_mode
-            continue
-        fi
-        printf '%s\n' "$out" >&2
-        return 1
-    done
 }
 
 if [ "$IS_WORKTREE" -eq 1 ]; then
@@ -314,16 +343,25 @@ if [ "$IS_WORKTREE" -eq 1 ]; then
                       need_switch=0
                   fi ;;
     esac
-    if [ "$need_switch" -eq 1 ] && ! attempt switch; then
-        move_aside "$WORKDIR" "branch switch refused (ignored files in the way, or git error above)"
-        attempt add || die "could not prepare $WORKDIR after moving the previous worktree aside"
+    if [ "$need_switch" -eq 1 ]; then
+        if ! out="$(switch_worktree 2>&1)"; then
+            printf '%s\n' "$out" >&2
+            move_aside "$WORKDIR" "branch switch refused (ignored files in the way, or the git error above)"
+            IS_WORKTREE=0
+        fi
     fi
-else
-    attempt add || die "could not create the worktree at $WORKDIR"
+fi
+if [ "$IS_WORKTREE" -eq 0 ]; then
+    out="$(add_worktree 2>&1)" || die "could not create the worktree at $WORKDIR: $out"
 fi
 
-WORKDIR="$(abs "$WORKDIR")"
+# --- verify before reporting ----------------------------------------------------------------
+is_our_worktree "$WORKDIR" || die "$WORKDIR is not a worktree of $RIG_ROOT after preparation"
 branch="$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+case "$MODE" in
+    local|remote|new) [ "$branch" = "$TARGET" ] || die "$WORKDIR is on $branch, expected $TARGET" ;;
+    detached)         [ "$branch" = "HEAD" ] || die "$WORKDIR is on $branch, expected a detached HEAD" ;;
+esac
 [ "$branch" != "HEAD" ] || branch="detached"
 sha="$(git -C "$WORKDIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 printf 'WORKTREE %s %s %s\n' "$WORKDIR" "$branch" "$sha"

--- a/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
@@ -30,11 +30,17 @@ The `## Implementation Worktrees` section names the workspace either as the sour
 `gc.work_branch`, as a branch and a commit id. In the branch case work from
 your OWN lane and never enter another agent's directory: read with `git -C
 "$GC_DIR" log -1 <commit>` and `git -C "$GC_DIR" show <commit>:<path>` (every
-worktree of the rig shares its refs); to run proof commands, put your own lane on the
-recorded branch first exactly as `do-work/implement` does for the lane case
-(the boundary test, then `git -C "$GC_DIR" switch --no-overwrite-ignore
-"<gc.work_branch>"`, and fail closed when git refuses: never `--force`, never
-a stash, never remove the colliding file). A `work_dir` naming an agent lane
+worktree of the rig shares its refs); to run proof commands, inspect the
+recorded commit DETACHED in your own lane: `git -C "$GC_DIR" switch --detach
+--no-overwrite-ignore <commit>` (the commit id the review setup recorded; if
+the context carries only the branch, resolve it first with `git -C "$GC_DIR"
+rev-parse "<gc.work_branch>"`), and fail closed when git refuses (an ignored
+file in your lane colliding with a tracked path, or a commit missing from the
+repository): never `--force`, never a stash, never remove the colliding file.
+A review lane never takes the branch itself: git allows one worktree per
+branch, only the writers (implement, then the fix lane) hold it, one at a
+time, and three reviewers detached at the same commit never contend and never
+block the fix lane. A `work_dir` naming an agent lane
 (`.worktrees/<rig>/lane-*`) is invalid: write an iterate finding against
 review setup instead of entering it.
 

--- a/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
@@ -25,6 +25,19 @@ checkout.
 
 Contract: `gc.work_dir` is the launcher rig root, not the implementation worktree.
 
+The `## Implementation Worktrees` section names the workspace either as the source anchor's
+`work_dir` or, when the source anchor has no `work_dir` and records
+`gc.work_branch`, as a branch and a commit id. In the branch case work from
+your OWN lane and never enter another agent's directory: read with `git -C
+"$GC_DIR" log -1 <commit>` and `git -C "$GC_DIR" show <commit>:<path>` (every
+worktree of the rig shares its refs); to run proof commands, put your own lane on the
+recorded branch first exactly as `do-work/implement` does for the lane case
+(the boundary test, then `git -C "$GC_DIR" switch --no-overwrite-ignore
+"<gc.work_branch>"`, and fail closed when git refuses: never `--force`, never
+a stash, never remove the colliding file). A `work_dir` naming an agent lane
+(`.worktrees/<rig>/lane-*`) is invalid: write an iterate finding against
+review setup instead of entering it.
+
 Write findings under the build artifact root. Required findings must include
 the relevant requirement or task reference plus the file, command, or artifact
 that proves the issue.

--- a/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
@@ -27,12 +27,34 @@ Contract: `gc.work_dir` is the launcher rig root, not the implementation worktre
 
 The `## Implementation Worktrees` section names the workspace either as the source anchor's
 `work_dir` or, when the source anchor has no `work_dir` and records
-`gc.work_branch`, as a branch and a commit id. In the branch case work from
+`gc.work_branch`, as a branch and a commit id. Read the CURRENT commit first:
+`gc.build.review_commit` on the workflow root bead (`gc.root_bead_id` on your
+claimed step bead; `gc bd show <workflow-root-id> --json`), which the review
+setup writes on its first run and the fix lane refreshes after every fix
+commit; fall back to the commit in the review context file only when that key
+is absent. The review loop re-runs this lane after a fix, and a commit read
+from a stale context re-reviews code that was already fixed and repeats
+resolved findings. In the branch case work from
 your OWN lane and never enter another agent's directory: read with `git -C
 "$GC_DIR" log -1 <commit>` and `git -C "$GC_DIR" show <commit>:<path>` (every
-worktree of the rig shares its refs); to run proof commands, inspect the
-recorded commit DETACHED in your own lane: `git -C "$GC_DIR" switch --detach
---no-overwrite-ignore <commit>` (the commit id the review setup recorded; if
+worktree of the rig shares its refs, and both commands are safe from any
+checkout of the rig's repository, the rig root included). To run proof
+commands, inspect the recorded commit DETACHED in your own lane, and prove
+the lane FIRST, before any `switch` or detach, with the boundary test
+`do-work/prepare-worktree` step 4 applies (every path resolved through
+symlinks, `pwd -P`): `git -C "$GC_DIR" rev-parse --show-toplevel` equals
+`$GC_DIR` itself; that top-level is neither the rig root (`gc.work_dir` on
+the workflow root bead) nor inside it; `git -C "$GC_DIR" rev-parse
+--git-common-dir` is the rig root's `.git`. A reviewer role with no configured
+`work_dir` starts in the RIG ROOT, the human checkout, and `$GC_DIR` then IS
+the rig root: when any part fails, switch and detach NOTHING in `$GC_DIR` (a
+detach run there moves the human checkout's HEAD), inspect by `git -C
+"$GC_DIR" show <commit>:<path>` and `git -C "$GC_DIR" log -1 <commit>` only,
+and if a proof command needs a checkout at the commit, close this lane with
+`gc.outcome=fail`, `gc.failure_class=no-lane` and the reason "no lane for
+this role", naming the fix: a `work_dir` for this role (README, Worker
+workspaces). Only when all three parts hold: `git -C "$GC_DIR" switch --detach
+--no-overwrite-ignore <commit>` (the current commit as read above; if
 the context carries only the branch, resolve it first with `git -C "$GC_DIR"
 rev-parse "<gc.work_branch>"`), and fail closed when git refuses (an ignored
 file in your lane colliding with a tracked path, or a commit missing from the

--- a/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.acceptance-review.md
@@ -25,16 +25,19 @@ checkout.
 
 Contract: `gc.work_dir` is the launcher rig root, not the implementation worktree.
 
-The `## Implementation Worktrees` section names the workspace either as the source anchor's
-`work_dir` or, when the source anchor has no `work_dir` and records
-`gc.work_branch`, as a branch and a commit id. Read the CURRENT commit first:
-`gc.build.review_commit` on the workflow root bead (`gc.root_bead_id` on your
-claimed step bead; `gc bd show <workflow-root-id> --json`), which the review
-setup writes on its first run and the fix lane refreshes after every fix
-commit; fall back to the commit in the review context file only when that key
-is absent. The review loop re-runs this lane after a fix, and a commit read
-from a stale context re-reviews code that was already fixed and repeats
-resolved findings. In the branch case work from
+The `## Implementation Worktrees` section carries one record per source
+anchor, and each names the workspace either as that source anchor's `work_dir`
+or, when the source anchor has no `work_dir` and records `gc.work_branch`, as
+a branch and a commit id. Read the CURRENT commit first, per source anchor:
+`gc.review_commit` on that source anchor bead (`gc bd show <source-anchor-id>
+--json`, the id from its record in the context), which the review setup writes
+on its first run and the fix lane refreshes after every fix commit on that
+item; fall back to the commit in that anchor's record in the review context
+file only when that key is absent. There is no workflow-wide review commit:
+separate drains put several items on independent branches, and each is
+inspected at its own commit. The review loop re-runs this lane after a fix,
+and a commit read from a stale context re-reviews code that was already fixed
+and repeats resolved findings. In the branch case work from
 your OWN lane and never enter another agent's directory: read with `git -C
 "$GC_DIR" log -1 <commit>` and `git -C "$GC_DIR" show <commit>:<path>` (every
 worktree of the rig shares its refs, and both commands are safe from any

--- a/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
@@ -28,6 +28,24 @@ is explicit.
 
 Contract: `gc.work_dir` is the launcher rig root, not the implementation worktree.
 
+When the review context records a branch and a commit instead of a `work_dir`
+(in its `## Implementation Worktrees` section: the source anchor has no
+`work_dir` and records `gc.work_branch`, the item was handed over by branch,
+and a directory is per agent), the workspace for
+fixes is your OWN lane, `$GC_DIR`, put on that branch exactly as
+`do-work/implement` does for the lane case: prove the lane first with the
+boundary test `do-work/prepare-worktree` step 4 applies (resolved `git -C
+"$GC_DIR" rev-parse --show-toplevel` equals `$GC_DIR`; neither the rig root
+nor inside it; `rev-parse --git-common-dir` is the rig root's `.git`), then,
+unless `git -C "$GC_DIR" branch --show-current` already prints that branch,
+`git -C "$GC_DIR" switch --no-overwrite-ignore "<gc.work_branch>"`; when any
+part fails or git refuses (an ignored file in your lane colliding with a path
+the branch tracks), fail this step before editing: never `--force`, never a
+stash, never remove the colliding file. Then `WORKTREE="$GC_DIR"`, `cd
+"$WORKTREE"`, verify `pwd -P` equals it before changing anything, and commit
+the fix on that branch. Never enter another agent's lane: a `work_dir` naming
+a lane other than `$GC_DIR` is invalid, fail closed.
+
 Set `code_review.verdict=done` only when acceptance, test evidence, and
 simplicity all approve after this pass. Set `code_review.verdict=iterate` when
 required fixes remain.

--- a/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
@@ -46,6 +46,25 @@ stash, never remove the colliding file. Then `WORKTREE="$GC_DIR"`, `cd
 the fix on that branch. Never enter another agent's lane: a `work_dir` naming
 a lane other than `$GC_DIR` is invalid, fail closed.
 
+This lane is the second WRITER in the item's lifecycle: a lane HOLDS the
+item's branch only while it is writing to it, and git allows one worktree per
+branch. The branch is free when you arrive because the implementation lane
+released it on handoff, and the review lanes only ever inspected its commit
+detached. Take it only when there is a fix to commit (a no-op summary needs no
+switch). If the switch fails because another worktree still holds the branch
+(git says "already checked out at <path>", or "already used by worktree at
+<path>" in newer git; `git worktree list` names the holder: a writer that
+crashed before releasing), fail this step closed with the holder's path in
+the close reason and mail the mayor (`gc mail send mayor -s "branch held:
+<gc.work_branch>" -m "<holder path>"`); the run operator (a human or the
+mayor) releases it with `git -C <holder lane> switch --detach`.
+Never enter that lane, never `--force`, never remove its checkout, never
+release another agent's lane. After the final commit and BEFORE closing this
+step with `gc.outcome=pass`, release the branch from your lane: `git -C
+"$GC_DIR" switch --detach` (HEAD stays at your commit; untracked files stay),
+then verify `git -C "$GC_DIR" branch --show-current` prints nothing, and name
+the commit id in this step's close reason.
+
 Set `code_review.verdict=done` only when acceptance, test evidence, and
 simplicity all approve after this pass. Set `code_review.verdict=iterate` when
 required fixes remain.

--- a/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
@@ -65,17 +65,21 @@ Refresh the review context after the fix commit and BEFORE releasing the
 branch. The review setup ran ONCE, outside the review loop, and the three
 review lanes inspect the commit it recorded; a context left at that commit
 makes every later attempt review the ORIGINAL code and repeat the findings you
-just resolved until the attempts run out. Rewrite the commit id (and the
-changed-file list, when the context carries one) in the review context file at
-`gc.build.code_review_context_path` on the workflow root, then record the new
-commit there too: `gc bd update "<workflow-root-id>" --set-metadata
-'gc.build.review_commit=<sha>'` (the review lanes read that key first and fall
-back to the context file's commit). The retry sequence is: fix, commit,
+just resolved until the attempts run out. The record is PER SOURCE ANCHOR:
+rewrite the commit id (and the changed-file list, when the context carries
+one) in the record of the source anchor you committed on, in the review
+context file at `gc.build.code_review_context_path` on the workflow root, then
+record the new commit on that source anchor: `gc bd update
+"<source-anchor-id>" --set-metadata 'gc.review_commit=<sha>'` (the review
+lanes read that anchor's key first and fall back to that anchor's record in
+the context file). Touch no other source anchor's record or key: the other
+items sit on independent branches at their own commits, and there is no
+workflow-wide review commit to update. The retry sequence is: fix, commit,
 refresh the context, release the branch; then the loop re-runs the reviewers
 on the new commit. Never leave the old commit in the context after a fix. The
 refresh applies in the `work_dir` case too (a fix committed in the per-item
-worktree): the commit id in the context and on the root are rewritten the same
-way; only the release below is the lane case.
+worktree): the commit id in the context and on the source anchor are
+rewritten the same way; only the release below is the lane case.
 
 After the final commit and BEFORE closing this
 step with `gc.outcome=pass`, release the branch from your lane: `git -C

--- a/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.apply-review-findings.md
@@ -59,11 +59,35 @@ the close reason and mail the mayor (`gc mail send mayor -s "branch held:
 <gc.work_branch>" -m "<holder path>"`); the run operator (a human or the
 mayor) releases it with `git -C <holder lane> switch --detach`.
 Never enter that lane, never `--force`, never remove its checkout, never
-release another agent's lane. After the final commit and BEFORE closing this
+release another agent's lane.
+
+Refresh the review context after the fix commit and BEFORE releasing the
+branch. The review setup ran ONCE, outside the review loop, and the three
+review lanes inspect the commit it recorded; a context left at that commit
+makes every later attempt review the ORIGINAL code and repeat the findings you
+just resolved until the attempts run out. Rewrite the commit id (and the
+changed-file list, when the context carries one) in the review context file at
+`gc.build.code_review_context_path` on the workflow root, then record the new
+commit there too: `gc bd update "<workflow-root-id>" --set-metadata
+'gc.build.review_commit=<sha>'` (the review lanes read that key first and fall
+back to the context file's commit). The retry sequence is: fix, commit,
+refresh the context, release the branch; then the loop re-runs the reviewers
+on the new commit. Never leave the old commit in the context after a fix. The
+refresh applies in the `work_dir` case too (a fix committed in the per-item
+worktree): the commit id in the context and on the root are rewritten the same
+way; only the release below is the lane case.
+
+After the final commit and BEFORE closing this
 step with `gc.outcome=pass`, release the branch from your lane: `git -C
 "$GC_DIR" switch --detach` (HEAD stays at your commit; untracked files stay),
 then verify `git -C "$GC_DIR" branch --show-current` prints nothing, and name
-the commit id in this step's close reason.
+the commit id in this step's close reason. This release is inside the guarded
+lane case above: it runs only after the boundary test passed and your switch
+onto the branch succeeded. A `$GC_DIR` that failed the boundary test (the rig
+root, a subdirectory of it, or a worktree of another repository) was never
+switched and detaches nothing, because a detach there would move the human
+checkout's HEAD; in the `work_dir` case the per-item worktree is already
+detached and shared with no one, so there is nothing to release.
 
 Set `code_review.verdict=done` only when acceptance, test evidence, and
 simplicity all approve after this pass. Set `code_review.verdict=iterate` when

--- a/gascity/assets/workflows/build-basic-review/{target}.setup-build-basic-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.setup-build-basic-review.md
@@ -23,14 +23,28 @@ list, and read `metadata.work_dir`. Verify every `work_dir` is an absolute
 existing git worktree and is different from the launcher root. If metadata is
 missing but `<launcher-root>/worktrees/<source-anchor-id>` exists and is a git
 worktree, record that recovered worktree and include a setup warning in the
-context. If no implementation worktree can be resolved, close this setup bead
-with `gc.outcome=fail` and record the missing source-anchor/worktree evidence.
+context. If no implementation worktree can be resolved and the lane case in
+the next paragraph does not apply, close this setup bead with
+`gc.outcome=fail` and record the missing source-anchor/worktree evidence.
+
+When the source anchor has no `work_dir` and records `gc.work_branch`
+(`prepare-worktree` ran in a lane and handed the item over by branch; a
+directory is per agent and is never handed to another agent), record the
+BRANCH (`gc.work_branch`) and the COMMIT id (`git -C "$GC_DIR" rev-parse
+"<gc.work_branch>"`, read from your own lane: every worktree of the rig shares
+its refs) in the context in place of a directory; the review and fix lanes
+resolve those in their own lanes. Never enter another agent's lane, and never
+record one as the workspace: a persisted `work_dir` that names an agent lane
+(`.worktrees/<rig>/lane-*`) is invalid, and so is a recorded branch that is
+missing from the repository; close this setup bead with `gc.outcome=fail` and
+say which, instead of pointing the review at a directory it must not enter.
 
 The context body must include an `## Implementation Worktrees` section before
 the artifact excerpts. For each source anchor include:
 
 - source anchor id
-- absolute implementation worktree path
+- absolute implementation worktree path, or, in the lane case, the recorded
+  branch (`gc.work_branch`) and commit id in place of a path
 - launcher root path for contrast
 - changed files and proof commands from the item or aggregate implementation
   summary

--- a/gascity/assets/workflows/build-basic-review/{target}.setup-build-basic-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.setup-build-basic-review.md
@@ -3,18 +3,26 @@ Prepare the build-basic starter factory review.
 Gather the requirements artifact, implementation plan, decomposition artifact,
 implementation summary, changed-file summaries, task evidence, and verification
 commands into one review context file under the build artifact root. Record that
-path on the workflow root as `gc.build.code_review_context_path`, and record the
-commit id the context carries on the workflow root as well:
-`gc bd update "<workflow-root-id>" --set-metadata 'gc.build.review_commit=<commit>'`.
-This setup runs ONCE, outside the review loop; the review lanes read
-`gc.build.review_commit` first and fall back to the context file's commit, and
-the fix lane refreshes both the context file and this key after every fix
-commit, so each attempt of the loop reviews the CURRENT commit, never the one
-this step saw.
+path on the workflow root as `gc.build.code_review_context_path`. The context
+carries one record PER SOURCE ANCHOR (separate drains produce several source
+anchors, each on its own branch at its own commit), and the commit each record
+carries is recorded on that source anchor, never on the workflow root:
+`gc bd update "<source-anchor-id>" --set-metadata 'gc.review_commit=<commit>'`,
+once per source anchor the context names (for a synthetic drain-unit convoy,
+the original drain member, never the synthetic convoy). There is no
+workflow-wide review commit: one key for several items would send every reader
+to one item's revision for all of them, and a fix on one item would overwrite
+the revision recorded for the others. This setup runs ONCE, outside the review
+loop; the review lanes read each source anchor's `gc.review_commit` first and
+fall back to that anchor's record in the context file, and the fix lane
+refreshes that anchor's record and key after every fix commit, so each attempt
+of the loop reviews the CURRENT commit of each item, never the one this step
+saw.
 
 The implementation source of truth is the closed source anchor/worktree recorded
-by the implementation summary and task evidence. Include the source anchor id,
-its `work_dir`, changed files, commit id, and proof commands in the context. The
+by the implementation summary and task evidence. Include, per source anchor,
+its id, its `work_dir`, changed files, commit id, and proof commands in the
+context. The
 launcher rig root may remain unchanged until an explicit publish step; do not
 present an unchanged root checkout as a review failure when the source
 anchor/worktree contains the verified implementation.
@@ -71,4 +79,5 @@ Do not invoke provider-native subagents. Gas City graph lanes are the
 delegation mechanism.
 
 Close this setup bead with `gc.outcome=pass` only after the review context path
-and `gc.build.review_commit` are recorded.
+is recorded on the workflow root and `gc.review_commit` is recorded on every
+source anchor the context names.

--- a/gascity/assets/workflows/build-basic-review/{target}.setup-build-basic-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.setup-build-basic-review.md
@@ -3,7 +3,14 @@ Prepare the build-basic starter factory review.
 Gather the requirements artifact, implementation plan, decomposition artifact,
 implementation summary, changed-file summaries, task evidence, and verification
 commands into one review context file under the build artifact root. Record that
-path on the workflow root as `gc.build.code_review_context_path`.
+path on the workflow root as `gc.build.code_review_context_path`, and record the
+commit id the context carries on the workflow root as well:
+`gc bd update "<workflow-root-id>" --set-metadata 'gc.build.review_commit=<commit>'`.
+This setup runs ONCE, outside the review loop; the review lanes read
+`gc.build.review_commit` first and fall back to the context file's commit, and
+the fix lane refreshes both the context file and this key after every fix
+commit, so each attempt of the loop reviews the CURRENT commit, never the one
+this step saw.
 
 The implementation source of truth is the closed source anchor/worktree recorded
 by the implementation summary and task evidence. Include the source anchor id,
@@ -64,4 +71,4 @@ Do not invoke provider-native subagents. Gas City graph lanes are the
 delegation mechanism.
 
 Close this setup bead with `gc.outcome=pass` only after the review context path
-is recorded.
+and `gc.build.review_commit` are recorded.

--- a/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
@@ -18,6 +18,15 @@ Contract: `gc.work_dir` is the launcher rig root, not the implementation worktre
 Write findings under the build artifact root. Required findings must be tied to
 specific changed files or artifacts and must explain the smallest useful fix.
 
+Read the changed files where the review context puts them: the source
+anchor's `work_dir`, or, when the source anchor has no `work_dir` and records
+`gc.work_branch`, the recorded branch and commit read from your OWN lane
+(`git -C "$GC_DIR" show <commit>:<path>`; every worktree of the rig shares its
+refs). Never enter another agent's lane; to run a command in the branch case,
+put your own lane on the recorded branch as the acceptance lane does (the
+boundary test, then `git -C "$GC_DIR" switch --no-overwrite-ignore
+"<gc.work_branch>"`, fail closed when git refuses).
+
 Close with `gc.outcome=pass`,
 `code_review.simplicity_verdict=approve|iterate`, and
 `code_review.output_path=<simplicity review report path>`.

--- a/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
@@ -18,14 +18,17 @@ Contract: `gc.work_dir` is the launcher rig root, not the implementation worktre
 Write findings under the build artifact root. Required findings must be tied to
 specific changed files or artifacts and must explain the smallest useful fix.
 
-Read the changed files where the review context puts them: the source
-anchor's `work_dir`, or, when the source anchor has no `work_dir` and records
-`gc.work_branch`, the recorded branch and commit read from your OWN lane
-(`git -C "$GC_DIR" show <commit>:<path>`; every worktree of the rig shares its
-refs). Read the CURRENT commit first from `gc.build.review_commit` on the
-workflow root bead (written by the review setup, refreshed by the fix lane
-after every fix commit; the loop re-runs this lane after a fix) and fall back
-to the review context file's commit only when that key is absent. Never enter
+Read the changed files where the review context puts them, per source anchor
+(the context carries one record per source anchor): that anchor's `work_dir`,
+or, when the source anchor has no `work_dir` and records `gc.work_branch`, the
+recorded branch and commit read from your OWN lane (`git -C "$GC_DIR" show
+<commit>:<path>`; every worktree of the rig shares its refs). Read the CURRENT
+commit first from `gc.review_commit` on that source anchor bead (`gc bd show
+<source-anchor-id> --json`; written by the review setup, refreshed by the fix
+lane after every fix commit on that item; the loop re-runs this lane after a
+fix) and fall back to that anchor's record in the review context file only
+when that key is absent; there is no workflow-wide review commit, each item is
+inspected at its own. Never enter
 another agent's lane; to run a command in the branch case, inspect the
 recorded commit DETACHED in your own lane as the acceptance lane does, and as
 it does prove the lane FIRST, before any `switch` or detach, with the boundary

--- a/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
@@ -23,9 +23,13 @@ anchor's `work_dir`, or, when the source anchor has no `work_dir` and records
 `gc.work_branch`, the recorded branch and commit read from your OWN lane
 (`git -C "$GC_DIR" show <commit>:<path>`; every worktree of the rig shares its
 refs). Never enter another agent's lane; to run a command in the branch case,
-put your own lane on the recorded branch as the acceptance lane does (the
-boundary test, then `git -C "$GC_DIR" switch --no-overwrite-ignore
-"<gc.work_branch>"`, fail closed when git refuses).
+inspect the recorded commit DETACHED in your own lane as the acceptance lane
+does (`git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>`,
+resolving the branch first with `git -C "$GC_DIR" rev-parse
+"<gc.work_branch>"` when the context carries only the branch; fail closed when
+git refuses). A review lane never takes the branch itself: git allows one
+worktree per branch, only the writers hold it, and reviewers detached at one
+commit never contend.
 
 Close with `gc.outcome=pass`,
 `code_review.simplicity_verdict=approve|iterate`, and

--- a/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.simplicity-review.md
@@ -22,10 +22,25 @@ Read the changed files where the review context puts them: the source
 anchor's `work_dir`, or, when the source anchor has no `work_dir` and records
 `gc.work_branch`, the recorded branch and commit read from your OWN lane
 (`git -C "$GC_DIR" show <commit>:<path>`; every worktree of the rig shares its
-refs). Never enter another agent's lane; to run a command in the branch case,
-inspect the recorded commit DETACHED in your own lane as the acceptance lane
-does (`git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>`,
-resolving the branch first with `git -C "$GC_DIR" rev-parse
+refs). Read the CURRENT commit first from `gc.build.review_commit` on the
+workflow root bead (written by the review setup, refreshed by the fix lane
+after every fix commit; the loop re-runs this lane after a fix) and fall back
+to the review context file's commit only when that key is absent. Never enter
+another agent's lane; to run a command in the branch case, inspect the
+recorded commit DETACHED in your own lane as the acceptance lane does, and as
+it does prove the lane FIRST, before any `switch` or detach, with the boundary
+test `do-work/prepare-worktree` step 4 applies (resolved `git -C "$GC_DIR"
+rev-parse --show-toplevel` equals `$GC_DIR`; neither the rig root nor inside
+it; `rev-parse --git-common-dir` is the rig root's `.git`). A reviewer role
+with no configured `work_dir` starts in the RIG ROOT, the human checkout: when
+any part fails, this lane switches and detaches nothing there (a detach run
+there moves the human checkout's HEAD), inspects by `git -C "$GC_DIR" show
+<commit>:<path>` and `git -C "$GC_DIR" log -1 <commit>` only, and if a proof
+command needs a checkout at the commit closes with `gc.outcome=fail`,
+`gc.failure_class=no-lane` and the reason "no lane for this role", naming the
+fix: a `work_dir` for this role (README, Worker workspaces). Only when all
+three parts hold: `git -C "$GC_DIR" switch --detach --no-overwrite-ignore
+<commit>` (resolving the branch first with `git -C "$GC_DIR" rev-parse
 "<gc.work_branch>"` when the context carries only the branch; fail closed when
 git refuses). A review lane never takes the branch itself: git allows one
 worktree per branch, only the writers hold it, and reviewers detached at one

--- a/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
@@ -24,10 +24,25 @@ Read the changed files where the review context puts them: the source
 anchor's `work_dir`, or, when the source anchor has no `work_dir` and records
 `gc.work_branch`, the recorded branch and commit read from your OWN lane
 (`git -C "$GC_DIR" show <commit>:<path>`; every worktree of the rig shares its
-refs). Never enter another agent's lane; to run a command in the branch case,
-inspect the recorded commit DETACHED in your own lane as the acceptance lane
-does (`git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>`,
-resolving the branch first with `git -C "$GC_DIR" rev-parse
+refs). Read the CURRENT commit first from `gc.build.review_commit` on the
+workflow root bead (written by the review setup, refreshed by the fix lane
+after every fix commit; the loop re-runs this lane after a fix) and fall back
+to the review context file's commit only when that key is absent. Never enter
+another agent's lane; to run a command in the branch case, inspect the
+recorded commit DETACHED in your own lane as the acceptance lane does, and as
+it does prove the lane FIRST, before any `switch` or detach, with the boundary
+test `do-work/prepare-worktree` step 4 applies (resolved `git -C "$GC_DIR"
+rev-parse --show-toplevel` equals `$GC_DIR`; neither the rig root nor inside
+it; `rev-parse --git-common-dir` is the rig root's `.git`). A reviewer role
+with no configured `work_dir` starts in the RIG ROOT, the human checkout: when
+any part fails, this lane switches and detaches nothing there (a detach run
+there moves the human checkout's HEAD), inspects by `git -C "$GC_DIR" show
+<commit>:<path>` and `git -C "$GC_DIR" log -1 <commit>` only, and if a proof
+command needs a checkout at the commit closes with `gc.outcome=fail`,
+`gc.failure_class=no-lane` and the reason "no lane for this role", naming the
+fix: a `work_dir` for this role (README, Worker workspaces). Only when all
+three parts hold: `git -C "$GC_DIR" switch --detach --no-overwrite-ignore
+<commit>` (resolving the branch first with `git -C "$GC_DIR" rev-parse
 "<gc.work_branch>"` when the context carries only the branch; fail closed when
 git refuses). A review lane never takes the branch itself: git allows one
 worktree per branch, only the writers hold it, and reviewers detached at one

--- a/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
@@ -25,9 +25,13 @@ anchor's `work_dir`, or, when the source anchor has no `work_dir` and records
 `gc.work_branch`, the recorded branch and commit read from your OWN lane
 (`git -C "$GC_DIR" show <commit>:<path>`; every worktree of the rig shares its
 refs). Never enter another agent's lane; to run a command in the branch case,
-put your own lane on the recorded branch as the acceptance lane does (the
-boundary test, then `git -C "$GC_DIR" switch --no-overwrite-ignore
-"<gc.work_branch>"`, fail closed when git refuses).
+inspect the recorded commit DETACHED in your own lane as the acceptance lane
+does (`git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>`,
+resolving the branch first with `git -C "$GC_DIR" rev-parse
+"<gc.work_branch>"` when the context carries only the branch; fail closed when
+git refuses). A review lane never takes the branch itself: git allows one
+worktree per branch, only the writers hold it, and reviewers detached at one
+commit never contend.
 
 Close with `gc.outcome=pass`,
 `code_review.test_evidence_verdict=approve|iterate`, and

--- a/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
@@ -20,6 +20,15 @@ Write concrete findings under the build artifact root. Distinguish missing
 proof from real product defects so the fix lane can either run the missing
 command or change code.
 
+Read the changed files where the review context puts them: the source
+anchor's `work_dir`, or, when the source anchor has no `work_dir` and records
+`gc.work_branch`, the recorded branch and commit read from your OWN lane
+(`git -C "$GC_DIR" show <commit>:<path>`; every worktree of the rig shares its
+refs). Never enter another agent's lane; to run a command in the branch case,
+put your own lane on the recorded branch as the acceptance lane does (the
+boundary test, then `git -C "$GC_DIR" switch --no-overwrite-ignore
+"<gc.work_branch>"`, fail closed when git refuses).
+
 Close with `gc.outcome=pass`,
 `code_review.test_evidence_verdict=approve|iterate`, and
 `code_review.output_path=<test evidence report path>`.

--- a/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
+++ b/gascity/assets/workflows/build-basic-review/{target}.test-evidence-review.md
@@ -20,14 +20,17 @@ Write concrete findings under the build artifact root. Distinguish missing
 proof from real product defects so the fix lane can either run the missing
 command or change code.
 
-Read the changed files where the review context puts them: the source
-anchor's `work_dir`, or, when the source anchor has no `work_dir` and records
-`gc.work_branch`, the recorded branch and commit read from your OWN lane
-(`git -C "$GC_DIR" show <commit>:<path>`; every worktree of the rig shares its
-refs). Read the CURRENT commit first from `gc.build.review_commit` on the
-workflow root bead (written by the review setup, refreshed by the fix lane
-after every fix commit; the loop re-runs this lane after a fix) and fall back
-to the review context file's commit only when that key is absent. Never enter
+Read the changed files where the review context puts them, per source anchor
+(the context carries one record per source anchor): that anchor's `work_dir`,
+or, when the source anchor has no `work_dir` and records `gc.work_branch`, the
+recorded branch and commit read from your OWN lane (`git -C "$GC_DIR" show
+<commit>:<path>`; every worktree of the rig shares its refs). Read the CURRENT
+commit first from `gc.review_commit` on that source anchor bead (`gc bd show
+<source-anchor-id> --json`; written by the review setup, refreshed by the fix
+lane after every fix commit on that item; the loop re-runs this lane after a
+fix) and fall back to that anchor's record in the review context file only
+when that key is absent; there is no workflow-wide review commit, each item is
+inspected at its own. Never enter
 another agent's lane; to run a command in the branch case, inspect the
 recorded commit DETACHED in your own lane as the acceptance lane does, and as
 it does prove the lane FIRST, before any `switch` or detach, with the boundary

--- a/gascity/assets/workflows/do-work-item/implement-item.md
+++ b/gascity/assets/workflows/do-work-item/implement-item.md
@@ -7,10 +7,25 @@ the item, write an item summary, and close only the source anchor on success.
 Do not infer the source anchor from dependency ids. Read the reserved convoy and
 source anchor metadata directly; when `gc bd show --json` returns a one-element
 list, unwrap the first element before reading metadata. `gc.work_dir` is the
-launcher rig root, not the implementation location. Use the authoritative
-worktree recorded on the source anchor, run `cd "$WORKTREE"`, and verify
-`pwd -P` equals `$WORKTREE` before any source read, source edit, test, file
-hash, `git add`, or `git commit`.
+launcher rig root, not the implementation location. Read `work_dir` from the
+source anchor (the authoritative worktree recorded there), set `WORKTREE` to
+it, run `cd "$WORKTREE"`, and verify `pwd -P` equals `$WORKTREE` before any
+source read, source edit, test, file hash, `git add`, or `git commit`.
+
+When the source anchor has no `work_dir` and records `gc.work_branch`
+(`prepare-worktree` ran in a lane and handed the item over by branch; a
+directory is per agent and is never handed to another agent), the worktree is
+your OWN lane, `$GC_DIR`, on the recorded branch: prove the lane with the
+boundary test `do-work/prepare-worktree` step 4 applies (resolved `git -C
+"$GC_DIR" rev-parse --show-toplevel` equals `$GC_DIR`; neither the rig root
+nor inside it; `rev-parse --git-common-dir` is the rig root's `.git`), then,
+unless `git -C "$GC_DIR" branch --show-current` already prints that branch,
+`git -C "$GC_DIR" switch --no-overwrite-ignore "<gc.work_branch>"`; when any
+part fails or git refuses (an ignored file in your lane colliding with a path
+the branch tracks), fail this step before editing: never `--force`, never a
+stash, never remove the colliding file. Then `WORKTREE="$GC_DIR"`. Never enter
+another agent's lane: a persisted `work_dir` naming a lane other than
+`$GC_DIR` is invalid, fail closed.
 
 Write or update the item summary with these schema-required body sections,
 using the exact `##` headings below in this order:

--- a/gascity/assets/workflows/do-work-item/implement-item.md
+++ b/gascity/assets/workflows/do-work-item/implement-item.md
@@ -27,6 +27,18 @@ stash, never remove the colliding file. Then `WORKTREE="$GC_DIR"`. Never enter
 another agent's lane: a persisted `work_dir` naming a lane other than
 `$GC_DIR` is invalid, fail closed.
 
+Release the branch when you hand off (the lane case): a lane HOLDS the item's
+branch only while it is writing to it, because git allows one worktree per
+branch and a branch left checked out in your lane blocks the next writer's
+switch (git: "already checked out at <your lane>", or "already used by
+worktree at <your lane>" in newer git). After the final commit and
+BEFORE closing this step with `gc.outcome=pass`, release the branch from your
+lane: `git -C "$GC_DIR" switch --detach` (HEAD stays at your commit; untracked
+files stay), then verify `git -C "$GC_DIR" branch --show-current` prints
+nothing, and name the commit id in this step's close reason. Readers inspect
+that commit detached (`git log -1 <gc.work_branch>`, `git show`), never on the
+branch, so the release loses nothing.
+
 Write or update the item summary with these schema-required body sections,
 using the exact `##` headings below in this order:
 

--- a/gascity/assets/workflows/do-work/close-source-anchor.md
+++ b/gascity/assets/workflows/do-work/close-source-anchor.md
@@ -7,9 +7,16 @@ is present; otherwise use `{{artifact_root}}/task-<source-anchor-id>-summary.md`
 
 When reading beads with `gc bd show --json`, handle both an object and a
 one-element list before reading metadata. `gc.work_dir` is the launcher rig
-root, not the implementation worktree. If the source anchor `work_dir` is
+root, not the implementation worktree. Unless the lane case below applies, if the source anchor `work_dir` is
 missing, equals the launcher root, or points at a worktree without the
 implementation commit, fail this step instead of closing the source anchor.
+
+When the source anchor has no `work_dir` and records `gc.work_branch`
+(`prepare-worktree` ran in a lane and handed the item over by branch), verify
+from your own lane instead: `git -C "$GC_DIR" log -1 <gc.work_branch>` shows
+the implementation commit (every worktree of the rig shares its refs) and the
+summary exists at the recorded summary path. Never enter another agent's lane
+to verify, and fail this step if the branch is missing from the repository.
 
 On success, close only `<source-anchor-id>` with `gc.outcome=pass`. Include the
 verified commit and summary path in the source-anchor close reason. Read the

--- a/gascity/assets/workflows/do-work/close-source-anchor.md
+++ b/gascity/assets/workflows/do-work/close-source-anchor.md
@@ -16,7 +16,9 @@ When the source anchor has no `work_dir` and records `gc.work_branch`
 from your own lane instead: `git -C "$GC_DIR" log -1 <gc.work_branch>` shows
 the implementation commit (every worktree of the rig shares its refs) and the
 summary exists at the recorded summary path. Never enter another agent's lane
-to verify, and fail this step if the branch is missing from the repository.
+to verify, and fail this step if the branch is missing from the repository. A
+persisted `work_dir` that names an agent lane (`.worktrees/<rig>/lane-*`) is
+invalid, whoever's it is: fail this step instead of entering it.
 
 On success, close only `<source-anchor-id>` with `gc.outcome=pass`. Include the
 verified commit and summary path in the source-anchor close reason. Read the

--- a/gascity/assets/workflows/do-work/implement.md
+++ b/gascity/assets/workflows/do-work/implement.md
@@ -11,19 +11,28 @@ When the source anchor has no `work_dir` and records `gc.work_branch`
 (`prepare-worktree` ran in the run operator's lane and recorded the item's
 branch instead of a directory), your own `$GC_DIR` is the worktree: it is a
 lane your `pre_start` put on the item's branch (the branch recorded by
-`prepare-worktree`); work there. Prove it before editing: `git -C "$GC_DIR"
-rev-parse --verify "refs/heads/<gc.work_branch>"` must succeed, and `git -C
-"$GC_DIR" branch --show-current` must print that branch. If it prints another
-branch or nothing, switch your own lane onto the recorded branch with `git -C
-"$GC_DIR" switch "<gc.work_branch>"` (refs are shared by every worktree of the
-rig, and `prepare-worktree` detached its lane from the branch so it is free);
-if git refuses, or the branch is missing from the repository, fail this step
-before editing. Then set `WORKTREE="$GC_DIR"`; `cd "$WORKTREE"` and the `pwd
--P` check below hold trivially. Never enter another agent's lane, and never
-treat a persisted `work_dir` that points into `.worktrees/<rig>/lane-*` of
-another agent as yours: a `work_dir` naming a lane other than `$GC_DIR` is
-invalid, fail this step before editing. Otherwise the steps below apply
-unchanged.
+`prepare-worktree`); work there. Prove it before editing, and before any
+`switch`, with the boundary test `prepare-worktree` step 4 applies (every
+path resolved through symlinks, `pwd -P`): `git -C "$GC_DIR" rev-parse
+--show-toplevel` equals `$GC_DIR` itself, that top-level is neither the rig
+root (`gc.work_dir` on the workflow root bead) nor inside the rig root, and
+`git -C "$GC_DIR" rev-parse --git-common-dir` is the rig root's `.git`. When
+any part fails, `$GC_DIR` is not a lane (a subdirectory of the human
+checkout, or a worktree of another repository): fail this step before
+editing and never run `switch` there, because switching a subdirectory of
+the rig checkout would switch the human checkout's branch. Then `git -C
+"$GC_DIR" rev-parse --verify "refs/heads/<gc.work_branch>"` must succeed, and
+`git -C "$GC_DIR" branch --show-current` must print that branch. If it prints
+another branch or nothing, switch your own lane onto the recorded branch with
+`git -C "$GC_DIR" switch "<gc.work_branch>"` (refs are shared by every
+worktree of the rig, and `prepare-worktree` detached its lane from the branch
+so it is free); if git refuses, or the branch is missing from the repository,
+fail this step before editing. Then set `WORKTREE="$GC_DIR"`; `cd
+"$WORKTREE"` and the `pwd -P` check below hold trivially. Never enter another
+agent's lane, and never treat a persisted `work_dir` that points into
+`.worktrees/<rig>/lane-*` of another agent as yours: a `work_dir` naming a
+lane other than `$GC_DIR` is invalid, fail this step before editing.
+Otherwise the steps below apply unchanged.
 
 Do not infer the source anchor from dependency ids such as the
 `prepare-worktree` step. Read the claimed step bead's `gc.root_bead_id`, read

--- a/gascity/assets/workflows/do-work/implement.md
+++ b/gascity/assets/workflows/do-work/implement.md
@@ -4,13 +4,26 @@ synthetic drain-unit convoy, the source anchor is the original drain member in
 `gc.drain_member_id`, not the synthetic convoy id. Read `work_dir` from the source anchor, never read `work_dir` from the synthetic drain-unit convoy,
 validate that it is an absolute existing git worktree, set `WORKTREE` to that
 path, then `cd "$WORKTREE"` before reading or editing source files. If
-`work_dir` is missing, invalid, or points at the launcher checkout, fail this step before editing.
+`work_dir` is missing, invalid, or points at the launcher checkout, fail this step before editing;
+the lane case in the next paragraph is the one exception to a missing `work_dir`.
 
-When `work_dir` equals `$GC_DIR` (`prepare-worktree` recorded the lane gc gave
-this session: `$GC_DIR` is already a git worktree of the rig on a branch and
-not the rig root), there is nothing to switch into: work in `$GC_DIR`, where
-the session already is; `cd "$WORKTREE"` and the `pwd -P` check below then
-hold trivially. Otherwise the steps below apply unchanged.
+When the source anchor has no `work_dir` and records `gc.work_branch`
+(`prepare-worktree` ran in the run operator's lane and recorded the item's
+branch instead of a directory), your own `$GC_DIR` is the worktree: it is a
+lane your `pre_start` put on the item's branch (the branch recorded by
+`prepare-worktree`); work there. Prove it before editing: `git -C "$GC_DIR"
+rev-parse --verify "refs/heads/<gc.work_branch>"` must succeed, and `git -C
+"$GC_DIR" branch --show-current` must print that branch. If it prints another
+branch or nothing, switch your own lane onto the recorded branch with `git -C
+"$GC_DIR" switch "<gc.work_branch>"` (refs are shared by every worktree of the
+rig, and `prepare-worktree` detached its lane from the branch so it is free);
+if git refuses, or the branch is missing from the repository, fail this step
+before editing. Then set `WORKTREE="$GC_DIR"`; `cd "$WORKTREE"` and the `pwd
+-P` check below hold trivially. Never enter another agent's lane, and never
+treat a persisted `work_dir` that points into `.worktrees/<rig>/lane-*` of
+another agent as yours: a `work_dir` naming a lane other than `$GC_DIR` is
+invalid, fail this step before editing. Otherwise the steps below apply
+unchanged.
 
 Do not infer the source anchor from dependency ids such as the
 `prepare-worktree` step. Read the claimed step bead's `gc.root_bead_id`, read

--- a/gascity/assets/workflows/do-work/implement.md
+++ b/gascity/assets/workflows/do-work/implement.md
@@ -65,6 +65,22 @@ anchor boundary, run sandboxed verification from inside the worktree, and make a
 focused commit in the worktree. Leave the source anchor open for
 `close-source-anchor`; close only this implementation step when done.
 
+Release the branch when you hand off (the lane case). A lane HOLDS the item's
+branch only while it is writing to it: git allows one worktree per branch, so
+a branch left checked out in your lane blocks the review fix lane's switch
+(git: "already checked out at <your lane>", or "already used by worktree at
+<your lane>" in newer git) and forces every later writer to fail closed.
+After the final commit and BEFORE closing this step with `gc.outcome=pass`,
+release the branch from your lane: `git -C "$GC_DIR" switch --detach` (HEAD
+stays at your commit; untracked files stay), then verify
+`git -C "$GC_DIR" branch --show-current` prints nothing, and name the commit
+id in this step's close reason. Nothing is lost: `close-source-anchor` reads
+the commit by branch (`git log -1 <gc.work_branch>`), the review lanes inspect
+it detached at that commit, and the fix lane takes the branch, commits, and
+releases it the same way. This release is the lane case only; the per-item
+`work_dir` worktree of the rig-root path is already detached and is shared
+with no one.
+
 Write or update the task summary with these schema-required body sections,
 using the exact `##` headings below in this order:
 

--- a/gascity/assets/workflows/do-work/implement.md
+++ b/gascity/assets/workflows/do-work/implement.md
@@ -6,6 +6,12 @@ validate that it is an absolute existing git worktree, set `WORKTREE` to that
 path, then `cd "$WORKTREE"` before reading or editing source files. If
 `work_dir` is missing, invalid, or points at the launcher checkout, fail this step before editing.
 
+When `work_dir` equals `$GC_DIR` (`prepare-worktree` recorded the lane gc gave
+this session: `$GC_DIR` is already a git worktree of the rig on a branch and
+not the rig root), there is nothing to switch into: work in `$GC_DIR`, where
+the session already is; `cd "$WORKTREE"` and the `pwd -P` check below then
+hold trivially. Otherwise the steps below apply unchanged.
+
 Do not infer the source anchor from dependency ids such as the
 `prepare-worktree` step. Read the claimed step bead's `gc.root_bead_id`, read
 that do-work root with `gc bd show <root-bead-id> --json`, then read the root

--- a/gascity/assets/workflows/do-work/implement.md
+++ b/gascity/assets/workflows/do-work/implement.md
@@ -24,11 +24,17 @@ the rig checkout would switch the human checkout's branch. Then `git -C
 "$GC_DIR" rev-parse --verify "refs/heads/<gc.work_branch>"` must succeed, and
 `git -C "$GC_DIR" branch --show-current` must print that branch. If it prints
 another branch or nothing, switch your own lane onto the recorded branch with
-`git -C "$GC_DIR" switch "<gc.work_branch>"` (refs are shared by every
-worktree of the rig, and `prepare-worktree` detached its lane from the branch
-so it is free); if git refuses, or the branch is missing from the repository,
-fail this step before editing. Then set `WORKTREE="$GC_DIR"`; `cd
-"$WORKTREE"` and the `pwd -P` check below hold trivially. Never enter another
+`git -C "$GC_DIR" switch --no-overwrite-ignore "<gc.work_branch>"` (refs are
+shared by every worktree of the rig, and `prepare-worktree` detached its lane
+from the branch so it is free). `--no-overwrite-ignore` makes git refuse when
+an ignored file in your lane (a build output, say) collides with a path the
+branch tracks; a plain `switch` would overwrite that file silently, and the
+lane helper `worker-worktree.sh` protects the same case. If git refuses, for
+that or any other reason, or the branch is missing from the repository, fail
+this step before editing: never `--force`, never a stash (the stash stack is
+shared by every worktree of the rig), and never remove the colliding file.
+Then set `WORKTREE="$GC_DIR"`; `cd "$WORKTREE"` and the `pwd -P` check below
+hold trivially. Never enter another
 agent's lane, and never treat a persisted `work_dir` that points into
 `.worktrees/<rig>/lane-*` of another agent as yours: a `work_dir` naming a
 lane other than `$GC_DIR` is invalid, fail this step before editing.
@@ -42,7 +48,10 @@ metadata `gc.input_convoy_id`. Read that input convoy with `gc bd show
 first element before reading metadata. If the input convoy has
 `gc.synthetic_kind=drain-unit-convoy`, use its `gc.drain_member_id` as the
 source anchor. Otherwise use the input convoy id as the source anchor. Then
-read the source anchor and use only its `work_dir` metadata as `WORKTREE`.
+read the source anchor and use only its `work_dir` metadata as `WORKTREE`,
+or, when it has no `work_dir` and records `gc.work_branch`, your own lane
+`$GC_DIR` on that branch, resolved as the lane paragraph above says; never any
+other directory.
 
 `gc.work_dir` is the launcher rig root, not the implementation worktree. Use
 `gc.work_dir` only later to run `.gc/scripts/checks/build-artifact-valid.sh`.

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -73,7 +73,13 @@ setup only. Do not edit source files in the launcher checkout.
      --show-current` prints nothing.
    Do NOT persist `work_dir` in the lane case: step 6 is skipped. A directory
    is per agent and is never handed to another agent; the next role works in
-   its own lane on the recorded branch.
+   its own lane on the recorded branch. The source anchor then has no
+   `work_dir` and records `gc.work_branch`, and every later step that reads
+   `work_dir` (implement, close-source-anchor, the review setup and its review
+   and fix lanes) resolves that case in its OWN lane: it switches its lane onto
+   the branch with `git switch --no-overwrite-ignore "<gc.work_branch>"` to
+   work, or reads the branch's commit with `git log -1` / `git show` to
+   inspect, and never enters another agent's lane.
    Otherwise (the session started in the rig root; the role has no lane),
    continue with step 5.
 5. Create or reuse a deterministic git worktree at

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -20,7 +20,17 @@ setup only. Do not edit source files in the launcher checkout.
      drain member
 3. Validate context path {{context_path}}, files ownership, and verification
    policy for the resolved source anchor.
-4. Create or reuse a deterministic git worktree at
+4. Check the workspace gc gave this session before creating anything. When
+   `$GC_DIR` is already a git worktree of the rig on a branch (the agent's
+   lane, prepared by its `pre_start`: `git -C "$GC_DIR" rev-parse
+   --is-inside-work-tree` prints `true` and `git -C "$GC_DIR" branch
+   --show-current` prints a branch name, or the `pre_start` log says so, and
+   `$GC_DIR` is not the rig root), this step creates nothing: set
+   `WORKTREE="$GC_DIR"` and continue at step 6. The lane is the isolated
+   worktree; the rig root stays a human checkout that no step touches.
+   Otherwise (the session started in the rig root; the role has no lane),
+   continue with step 5.
+5. Create or reuse a deterministic git worktree at
    `$(pwd)/worktrees/<source-anchor-id>`, based on the up-to-date remote
    default branch — never the launcher's local `HEAD`, which may be behind
    `origin`. If the path is missing:
@@ -48,7 +58,7 @@ setup only. Do not edit source files in the launcher checkout.
    - Create the worktree detached at the freshly fetched tip:
      `git worktree add "$WORKTREE" --detach "origin/$DEFAULT_BRANCH"`.
    If the path exists but is not the worktree for this repository, fail closed.
-5. Persist the absolute path on the source anchor with
+6. Persist the absolute path on the source anchor with
    `gc bd update <source-anchor-id> --set-metadata work_dir=<absolute worktree path>`.
    For synthetic drain-unit convoys, never persist `work_dir` on the synthetic drain-unit convoy; the original drain member/source anchor is authoritative.
    Verify the source anchor now has `work_dir` before closing this step with

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -25,11 +25,34 @@ setup only. Do not edit source files in the launcher checkout.
    lane, prepared by its `pre_start`: `git -C "$GC_DIR" rev-parse
    --is-inside-work-tree` prints `true` and `git -C "$GC_DIR" branch
    --show-current` prints a branch name, or the `pre_start` log says so, and
-   `$GC_DIR` is not the rig root), this step creates nothing and hands no
-   directory to anyone: a lane is per agent (this one is the run operator's),
-   and the item's BRANCH is the handoff. Every worktree of the rig shares its
-   refs, so a branch made visible here is reachable from the implementation
-   worker's own lane.
+   `$GC_DIR` is not the rig root), this MAY be the lane case. Prove it with
+   the boundary test below before recording a branch or detaching anything:
+   those two probes also succeed from any SUBDIRECTORY of a checkout, and a
+   subdirectory of a human checkout must never be detached. In the lane case
+   this step creates nothing and hands no directory to anyone: a lane is per
+   agent (this one is the run operator's), and the item's BRANCH is the
+   handoff. Every worktree of the rig shares its refs, so a branch made
+   visible here is reachable from the implementation worker's own lane.
+   - Boundary test. Resolve every path through symlinks before comparing
+     (`cd <path> && pwd -P`, or `realpath`; on macOS `/tmp` resolves to
+     `/private/tmp`). ALL three must hold:
+     1. The canonical git top-level of `$GC_DIR` IS `$GC_DIR`: `git -C
+        "$GC_DIR" rev-parse --show-toplevel`, resolved, equals `$GC_DIR`,
+        resolved. A subdirectory of any checkout fails this.
+     2. That top-level is NOT the rig root and is NOT inside the rig root
+        (the launcher checkout: `gc.work_dir` on the workflow root bead read
+        in step 1, resolved). Equality fails, and so does a prefix match of
+        the resolved rig root path plus a path separator.
+     3. `$GC_DIR` belongs to the rig's repository: `git -C "$GC_DIR"
+        rev-parse --git-common-dir`, resolved, is the same directory as the
+        rig root's `.git` (`git -C <rig root> rev-parse --git-common-dir`,
+        resolved). A worktree of another repository fails this.
+     When any part fails, this is NOT the lane case: record no branch, run
+     no `switch` in `$GC_DIR`, detach nothing (a `switch --detach` in a
+     subdirectory of the rig checkout would detach the human checkout's
+     HEAD), and continue with step 5 exactly as before (the per-item
+     worktree under `$(pwd)/worktrees/<source-anchor-id>`, then step 6
+     persists `work_dir`).
    - Resolve the item's branch: `BRANCH="$(git -C "$GC_DIR" branch
      --show-current)"` is the branch `pre_start` put this lane on. If it
      prints nothing (the lane is detached), use `BRANCH=<source-anchor-id>`

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -25,9 +25,32 @@ setup only. Do not edit source files in the launcher checkout.
    lane, prepared by its `pre_start`: `git -C "$GC_DIR" rev-parse
    --is-inside-work-tree` prints `true` and `git -C "$GC_DIR" branch
    --show-current` prints a branch name, or the `pre_start` log says so, and
-   `$GC_DIR` is not the rig root), this step creates nothing: set
-   `WORKTREE="$GC_DIR"` and continue at step 6. The lane is the isolated
-   worktree; the rig root stays a human checkout that no step touches.
+   `$GC_DIR` is not the rig root), this step creates nothing and hands no
+   directory to anyone: a lane is per agent (this one is the run operator's),
+   and the item's BRANCH is the handoff. Every worktree of the rig shares its
+   refs, so a branch made visible here is reachable from the implementation
+   worker's own lane.
+   - Resolve the item's branch: `BRANCH="$(git -C "$GC_DIR" branch
+     --show-current)"` is the branch `pre_start` put this lane on. If it
+     prints nothing (the lane is detached), use `BRANCH=<source-anchor-id>`
+     and create it from HEAD with `git -C "$GC_DIR" branch "$BRANCH" HEAD`
+     (reuse the branch when it already exists in the repository).
+   - Record the branch on the source anchor with
+     `gc bd update <source-anchor-id> --set-metadata gc.work_branch=<branch>`.
+     This overwrites a claim-time stamp (older `gc` builds stamp the rig
+     root's branch). For synthetic drain-unit convoys, stamp the original
+     drain member/source anchor, never the synthetic drain-unit convoy.
+   - Detach this lane from the branch with `git -C "$GC_DIR" switch --detach`.
+     git allows one worktree per branch, so detaching frees the branch for
+     the next role's lane; HEAD stays at the same commit and untracked files
+     (staged skills, hooks) stay in place.
+   - Verify before closing this step with `gc.outcome=pass`: the source
+     anchor's `gc.work_branch` equals `$BRANCH`, `git -C "$GC_DIR" rev-parse
+     --verify "refs/heads/$BRANCH"` succeeds, and `git -C "$GC_DIR" branch
+     --show-current` prints nothing.
+   Do NOT persist `work_dir` in the lane case: step 6 is skipped. A directory
+   is per agent and is never handed to another agent; the next role works in
+   its own lane on the recorded branch.
    Otherwise (the session started in the rig root; the role has no lane),
    continue with step 5.
 5. Create or reuse a deterministic git worktree at

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -91,8 +91,18 @@ setup only. Do not edit source files in the launcher checkout.
      simplicity and test-evidence lanes) never takes the branch: it reads the
      branch's commit with `git log -1` / `git show`, or detaches its own lane
      at that commit (`git switch --detach --no-overwrite-ignore <commit>`) to
-     run commands there. Readers detached at one commit never contend, however
-     many run in parallel, and never block the next writer.
+     run commands there, after the same boundary test above that every
+     writer applies. A reader whose `$GC_DIR` fails it (a role with no
+     `work_dir` starts in the rig root, the human checkout) detaches nothing
+     and reads by `git show` and `git log` only. Readers detached at one
+     commit never contend, however many run in parallel, and never block the
+     next writer.
+   - A writer that commits after a commit was recorded for readers (the
+     review fix lane, after the review setup recorded the commit it reviews)
+     refreshes the recorded commit before it releases the branch: the review
+     context file and `gc.build.review_commit` on the workflow root, so the
+     next attempt's readers inspect the new commit, never the one the setup
+     saw.
    - A writer that crashed before releasing leaves the branch held. The next
      writer's switch then fails (git: "already checked out at <path>", or
      "already used by worktree at <path>" in newer git); that step fails

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -99,10 +99,12 @@ setup only. Do not edit source files in the launcher checkout.
      next writer.
    - A writer that commits after a commit was recorded for readers (the
      review fix lane, after the review setup recorded the commit it reviews)
-     refreshes the recorded commit before it releases the branch: the review
-     context file and `gc.build.review_commit` on the workflow root, so the
-     next attempt's readers inspect the new commit, never the one the setup
-     saw.
+     refreshes the recorded commit before it releases the branch: this
+     source anchor's record in the review context file and `gc.review_commit`
+     on this source anchor (per item, never a workflow-wide key: separate
+     drains put several items on independent branches, each inspected at its
+     own commit), so the next attempt's readers inspect the new commit, never
+     the one the setup saw, and no other item's recorded commit moves.
    - A writer that crashed before releasing leaves the branch held. The next
      writer's switch then fails (git: "already checked out at <path>", or
      "already used by worktree at <path>" in newer git); that step fails

--- a/gascity/assets/workflows/do-work/prepare-worktree.md
+++ b/gascity/assets/workflows/do-work/prepare-worktree.md
@@ -76,10 +76,31 @@ setup only. Do not edit source files in the launcher checkout.
    its own lane on the recorded branch. The source anchor then has no
    `work_dir` and records `gc.work_branch`, and every later step that reads
    `work_dir` (implement, close-source-anchor, the review setup and its review
-   and fix lanes) resolves that case in its OWN lane: it switches its lane onto
-   the branch with `git switch --no-overwrite-ignore "<gc.work_branch>"` to
-   work, or reads the branch's commit with `git log -1` / `git show` to
-   inspect, and never enters another agent's lane.
+   and fix lanes) resolves that case in its OWN lane under one lifecycle,
+   because git allows one worktree per branch: a lane HOLDS the item's branch
+   only while it is writing to it and RELEASES it when it hands off; every
+   reader INSPECTS the recorded commit detached, never on the branch.
+   - A writer (implement, then the review fix lane) switches its own lane
+     onto the branch with `git switch --no-overwrite-ignore "<gc.work_branch>"`,
+     commits there, and releases the branch the same way this step does,
+     `git -C "$GC_DIR" switch --detach`, after its final commit and before it
+     closes its step; every writer releases the branch the same way when it
+     hands off. HEAD stays at the commit, so nothing is lost: the next step
+     reads the commit by branch name.
+   - A reader (close-source-anchor, the review setup, the acceptance,
+     simplicity and test-evidence lanes) never takes the branch: it reads the
+     branch's commit with `git log -1` / `git show`, or detaches its own lane
+     at that commit (`git switch --detach --no-overwrite-ignore <commit>`) to
+     run commands there. Readers detached at one commit never contend, however
+     many run in parallel, and never block the next writer.
+   - A writer that crashed before releasing leaves the branch held. The next
+     writer's switch then fails (git: "already checked out at <path>", or
+     "already used by worktree at <path>" in newer git); that step fails
+     closed with the holder's path (from `git worktree list`) in its close
+     reason, and the run operator (a human or the mayor) releases the branch
+     with `git -C <holder lane> switch --detach`. A step never enters another
+     agent's lane and never releases it, and no step `--force`s past a
+     holder.
    Otherwise (the session started in the rig root; the role has no lane),
    continue with step 5.
 5. Create or reuse a deterministic git worktree at

--- a/gascity/assets/workflows/implementation-base/implement.md
+++ b/gascity/assets/workflows/implementation-base/implement.md
@@ -21,6 +21,19 @@ the branch tracks), fail this step before editing: never `--force`, never a
 stash, never remove the colliding file. Then `WORKTREE="$GC_DIR"`. Never enter
 another agent's lane: a persisted `work_dir` naming a lane other than
 `$GC_DIR` is invalid, fail closed.
+
+Release the branch when you hand off (the lane case): a lane HOLDS the item's
+branch only while it is writing to it, because git allows one worktree per
+branch and a branch left checked out in your lane blocks the next writer's
+switch (git: "already checked out at <your lane>", or "already used by
+worktree at <your lane>" in newer git). After the final commit and
+BEFORE closing this step with `gc.outcome=pass`, release the branch from your
+lane: `git -C "$GC_DIR" switch --detach` (HEAD stays at your commit; untracked
+files stay), then verify `git -C "$GC_DIR" branch --show-current` prints
+nothing, and name the commit id in this step's close reason. Readers inspect
+that commit detached (`git log -1 <gc.work_branch>`, `git show`), never on the
+branch, so the release loses nothing.
+
 `gc.work_dir` is the launcher rig root, not the implementation worktree. When
 reading beads with `gc bd show --json`, handle both an object and a one-element
 list before reading metadata.

--- a/gascity/assets/workflows/implementation-base/implement.md
+++ b/gascity/assets/workflows/implementation-base/implement.md
@@ -7,6 +7,20 @@ the source anchor for the close step.
 Default fallback behavior must still enforce the worktree contract: resolve the
 source anchor from workflow metadata, read `work_dir` from that source anchor,
 and `cd "$WORKTREE"` before source reads, edits, tests, hashes, or commits.
+When the source anchor has no `work_dir` and records `gc.work_branch`
+(`prepare-worktree` ran in a lane and handed the item over by branch; a
+directory is per agent and is never handed to another agent), the worktree is
+your OWN lane, `$GC_DIR`, on the recorded branch: prove the lane with the
+boundary test `do-work/prepare-worktree` step 4 applies (resolved `git -C
+"$GC_DIR" rev-parse --show-toplevel` equals `$GC_DIR`; neither the rig root
+nor inside it; `rev-parse --git-common-dir` is the rig root's `.git`), then,
+unless `git -C "$GC_DIR" branch --show-current` already prints that branch,
+`git -C "$GC_DIR" switch --no-overwrite-ignore "<gc.work_branch>"`; when any
+part fails or git refuses (an ignored file in your lane colliding with a path
+the branch tracks), fail this step before editing: never `--force`, never a
+stash, never remove the colliding file. Then `WORKTREE="$GC_DIR"`. Never enter
+another agent's lane: a persisted `work_dir` naming a lane other than
+`$GC_DIR` is invalid, fail closed.
 `gc.work_dir` is the launcher rig root, not the implementation worktree. When
 reading beads with `gc bd show --json`, handle both an object and a one-element
 list before reading metadata.

--- a/gascity/assets/workflows/implementation-item-base/implement-item.md
+++ b/gascity/assets/workflows/implementation-item-base/implement-item.md
@@ -26,6 +26,18 @@ the launcher rig root, not the implementation worktree. When reading beads
 with `gc bd show --json`, handle both an object and a one-element list before
 reading metadata.
 
+Release the branch when you hand off (the lane case): a lane HOLDS the item's
+branch only while it is writing to it, because git allows one worktree per
+branch and a branch left checked out in your lane blocks the next writer's
+switch (git: "already checked out at <your lane>", or "already used by
+worktree at <your lane>" in newer git). After the final commit and
+BEFORE closing this step with `gc.outcome=pass`, release the branch from your
+lane: `git -C "$GC_DIR" switch --detach` (HEAD stays at your commit; untracked
+files stay), then verify `git -C "$GC_DIR" branch --show-current` prints
+nothing, and name the commit id in this step's close reason. Readers inspect
+that commit detached (`git log -1 <gc.work_branch>`, `git show`), never on the
+branch, so the release loses nothing.
+
 Write the per-item implementation summary as a `gc.build.implementation-summary.v1`
 artifact and record its absolute path on the workflow root bead as
 `gc.implementation.summary_path` before closing.

--- a/gascity/assets/workflows/implementation-item-base/implement-item.md
+++ b/gascity/assets/workflows/implementation-item-base/implement-item.md
@@ -6,11 +6,25 @@ of implementation work with optional context from `{{context_path}}`. Do not
 create parallel work inside this shared-drain contract.
 
 Default fallback behavior must still enforce the worktree contract: resolve the
-source anchor from workflow metadata, read the authoritative worktree from the
-source anchor, and `cd "$WORKTREE"` before source reads, edits, tests, hashes,
-or commits. `gc.work_dir` is the launcher rig root, not the implementation
-worktree. When reading beads with `gc bd show --json`, handle both an object and a
-one-element list before reading metadata.
+source anchor from workflow metadata, read `work_dir` (the authoritative
+worktree) from the source anchor, and `cd "$WORKTREE"` before source reads,
+edits, tests, hashes, or commits. When the source anchor has no `work_dir` and
+records `gc.work_branch` (`prepare-worktree` ran in a lane and handed the item
+over by branch; a directory is per agent and is never handed to another
+agent), the worktree is your OWN lane, `$GC_DIR`, on the recorded branch:
+prove the lane with the boundary test `do-work/prepare-worktree` step 4
+applies (resolved `git -C "$GC_DIR" rev-parse --show-toplevel` equals
+`$GC_DIR`; neither the rig root nor inside it; `rev-parse --git-common-dir` is
+the rig root's `.git`), then, unless `git -C "$GC_DIR" branch --show-current`
+already prints that branch, `git -C "$GC_DIR" switch --no-overwrite-ignore
+"<gc.work_branch>"`; when any part fails or git refuses (an ignored file in
+your lane colliding with a path the branch tracks), fail this step before
+editing: never `--force`, never a stash, never remove the colliding file. Then
+`WORKTREE="$GC_DIR"`. Never enter another agent's lane: a persisted `work_dir`
+naming a lane other than `$GC_DIR` is invalid, fail closed. `gc.work_dir` is
+the launcher rig root, not the implementation worktree. When reading beads
+with `gc bd show --json`, handle both an object and a one-element list before
+reading metadata.
 
 Write the per-item implementation summary as a `gc.build.implementation-summary.v1`
 artifact and record its absolute path on the workflow root bead as

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -45,15 +45,18 @@ the bead's failure contract and close it instead of idling.
 
 Work in the directory your session started in (`$GC_DIR`); gc materializes
 your skills and hooks there. When a `pre_start` prepared it as a git worktree
-(this pack's `worker-worktree.sh`), it is already on a branch named for the
-claimed bead — or detached, with a WARN in the pre_start log, when that branch
-is checked out in another worktree; then create your branch before committing.
+(this pack's `worker-worktree.sh`), it is on a branch named for the claimed
+bead, or detached (no trigger bead, or that branch is checked out in another
+worktree, WARN in the pre_start log): if `git branch --show-current` prints
+nothing, create your branch in this directory before committing.
 
 If you start in the rig root and the rig forbids working there, create your
 own worktree outside it (`<city>/.worktrees/<rig>/<bead>`) from
 `origin/<default branch>`. If a branch named for the bead already exists,
 check that branch out in the new worktree instead of creating another.
 
+After the claim, compare the bead's `gc.work_branch` with your branch and
+restamp it when they differ (older `gc` builds stamp the rig root's branch).
 Before closing a bead whose work continues elsewhere, stamp its workspace so
 the next session starts there:
 

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -53,6 +53,13 @@ bead, or detached (no trigger bead, or that branch is checked out in another
 worktree; WARN in the pre_start log): if `git branch --show-current` prints
 nothing, create your branch in this directory before committing.
 
+If `$GC_DIR` is the rig root, this role has no `work_dir` in your city. When
+the rig's rules forbid working there, create your worktree under
+`<city>/.worktrees/<rig>/<bead>` from `origin/<default branch>` (check out
+the bead's branch if it already exists), work there, and mail the mayor that
+this role needs a lane (`work_dir` + `pre_start`, see README, Worker
+workspaces).
+
 After the claim, compare the bead's `gc.work_branch` with your branch and
 restamp it when they differ (older `gc` builds stamp the rig root's branch).
 Before closing a bead whose work continues elsewhere, stamp its workspace so

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -53,12 +53,11 @@ bead, or detached (no trigger bead, or that branch is checked out in another
 worktree; WARN in the pre_start log): if `git branch --show-current` prints
 nothing, create your branch in this directory before committing.
 
-If `$GC_DIR` is the rig root, this role has no `work_dir` in your city. When
-the rig's rules forbid working there, create your worktree under
-`<city>/.worktrees/<rig>/<bead>` from `origin/<default branch>` (check out
-the bead's branch if it already exists), work there, and mail the mayor that
-this role needs a lane (`work_dir` + `pre_start`, see README, Worker
-workspaces).
+If `$GC_DIR` is the rig root, this role has no `work_dir` in your city:
+create your worktree under `<city>/.worktrees/<rig>/<bead>` from
+`origin/<default branch>` (check out the bead's branch if it already exists),
+work there, and mail the mayor that this role needs a lane (`work_dir` +
+`pre_start`, see README, Worker workspaces).
 
 After the claim, compare the bead's `gc.work_branch` with your branch and
 restamp it when they differ (older `gc` builds stamp the rig root's branch).

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -24,6 +24,9 @@ Read its single JSON result:
   - `bead_id` as `CLAIMED_BEAD_ID`
   - `root_bead_id` as `CLAIMED_ROOT_BEAD_ID`
   - `continuation_group` as `CLAIMED_CONTINUATION_GROUP`
+  - A raw `gc hook --claim --drain-ack --json` line may omit `root_bead_id`
+    and `continuation_group` when they are empty; the claim wrapper prints
+    both. An absent key is an empty value, never a failed claim.
 - `action=drain`: already drain-acked. Exit now.
 - Non-zero exit or malformed result: report failure. Do not search, hand-repair
   assignment, or retry forever. Do not drain or mutate claim state; the command
@@ -37,6 +40,28 @@ A successful claim is authorization to execute immediately.
 Never ask a human whether to proceed after a successful claim. Do not stop for
 confirmation in a headless workflow. If required task input is missing, record
 the bead's failure contract and close it instead of idling.
+
+## Workspace
+
+Work in the directory your session started in (`$GC_DIR`); gc materializes
+your skills and hooks there. When a `pre_start` prepared it as a git worktree
+(this pack's `worker-worktree.sh`), it is already on a branch named for the
+claimed bead — or detached, with a WARN in the pre_start log, when that branch
+is checked out in another worktree; then create your branch before committing.
+
+If you start in the rig root and the rig forbids working there, create your
+own worktree outside it (`<city>/.worktrees/<rig>/<bead>`) from
+`origin/<default branch>`. If a branch named for the bead already exists,
+check that branch out in the new worktree instead of creating another.
+
+Before closing a bead whose work continues elsewhere, stamp its workspace so
+the next session starts there:
+
+```bash
+gc bd update "$CLAIMED_BEAD_ID" \
+  --set-metadata 'work_dir=<absolute worktree path>' \
+  --set-metadata 'gc.work_branch=<branch>'
+```
 
 ## Close
 

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -53,21 +53,22 @@ bead, or detached (no trigger bead, or that branch is checked out in another
 worktree; WARN in the pre_start log): if `git branch --show-current` prints
 nothing, create your branch in this directory before committing.
 
-If `$GC_DIR` is the rig root, this role has no `work_dir` in your city:
-create your worktree under `<city>/.worktrees/<rig>/<bead>` (check out the
-bead's branch if it already exists), work there, and mail the mayor that this
-role needs a lane (`work_dir` + `pre_start`, see README, Worker workspaces).
-Resolve the base of a new branch, never assume it, in the order
-`worker-worktree.sh` uses: the remote's default branch when the rig has a
-remote (`<remote>/HEAD`, else `<remote>/main`, else `<remote>/master`, where
-`<remote>` is `origin` or, when the remote has another name, that name from
-`git -C <rig root> remote`; fetch it first), else the rig checkout's current
-`HEAD`. Pin the base to a commit in the rig (`git -C <rig root> rev-parse
---verify '<base>^{commit}'`) and create the worktree from that commit
-(`git -C <rig root> worktree add -b <bead> <city>/.worktrees/<rig>/<bead>
-<commit>`). This fallback never fails for lack of a remote, and it never
-writes into the rig checkout: it fetches, reads refs, and registers the
-worktree from there; the checkout's HEAD and files do not move.
+A session outside a gc-made lane has no lane: this role has no `work_dir` in
+your city. Prove the lane before you write, with the three-part boundary test
+(every path resolved through symlinks, `pwd -P`): `git -C "$GC_DIR" rev-parse
+--show-toplevel` is `$GC_DIR` itself; that top-level is neither the rig root
+(`$GC_RIG_ROOT`) nor inside it; `git -C "$GC_DIR" rev-parse --git-common-dir`
+is the rig root's `.git`. When any part fails (`$GC_DIR` is the rig root, a
+directory inside it, or a checkout of another repository), create no
+worktree and write nothing into the rig checkout: no `switch`, no detach, no
+branch, no commit there. Read the item by `git -C "$GC_DIR" show
+<commit>:<path>` and `git -C "$GC_DIR" log -1 <commit>` only; a step that
+needs a checkout closes the item with `gc.outcome=fail` and
+`gc.failure_class=no-lane`, and its close reason says in one line that the
+city must give this role a lane (`[[patches.agent]]` with `work_dir` and
+`pre_start` in `city.toml`; README, Worker workspaces). A formula step whose
+own text creates the item's worktree (`do-work/prepare-worktree` in the rig
+root) runs unchanged.
 
 After the claim, compare the bead's `gc.work_branch` with your branch and
 restamp it when they differ (older `gc` builds stamp the rig root's branch).

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -54,10 +54,20 @@ worktree; WARN in the pre_start log): if `git branch --show-current` prints
 nothing, create your branch in this directory before committing.
 
 If `$GC_DIR` is the rig root, this role has no `work_dir` in your city:
-create your worktree under `<city>/.worktrees/<rig>/<bead>` from
-`origin/<default branch>` (check out the bead's branch if it already exists),
-work there, and mail the mayor that this role needs a lane (`work_dir` +
-`pre_start`, see README, Worker workspaces).
+create your worktree under `<city>/.worktrees/<rig>/<bead>` (check out the
+bead's branch if it already exists), work there, and mail the mayor that this
+role needs a lane (`work_dir` + `pre_start`, see README, Worker workspaces).
+Resolve the base of a new branch, never assume it, in the order
+`worker-worktree.sh` uses: the remote's default branch when the rig has a
+remote (`<remote>/HEAD`, else `<remote>/main`, else `<remote>/master`, where
+`<remote>` is `origin` or, when the remote has another name, that name from
+`git -C <rig root> remote`; fetch it first), else the rig checkout's current
+`HEAD`. Pin the base to a commit in the rig (`git -C <rig root> rev-parse
+--verify '<base>^{commit}'`) and create the worktree from that commit
+(`git -C <rig root> worktree add -b <bead> <city>/.worktrees/<rig>/<bead>
+<commit>`). This fallback never fails for lack of a remote, and it never
+writes into the rig checkout: it fetches, reads refs, and registers the
+worktree from there; the checkout's HEAD and files do not move.
 
 After the claim, compare the bead's `gc.work_branch` with your branch and
 restamp it when they differ (older `gc` builds stamp the rig root's branch).

--- a/gascity/template-fragments/gc-role-worker.template.md
+++ b/gascity/template-fragments/gc-role-worker.template.md
@@ -43,17 +43,15 @@ the bead's failure contract and close it instead of idling.
 
 ## Workspace
 
-Work in the directory your session started in (`$GC_DIR`); gc materializes
-your skills and hooks there. When a `pre_start` prepared it as a git worktree
-(this pack's `worker-worktree.sh`), it is on a branch named for the claimed
+Work in the directory your session started in (`$GC_DIR`). gc chose it from
+the agent's `work_dir`, created it, ran the agent's `pre_start` in it, and
+materialized your skills and hooks there. You never pick, create, or hunt for
+a workspace, and you never work in the rig root: the rig root is a human
+checkout. When the `pre_start` was this pack's `worker-worktree.sh`, the
+directory is a git worktree of the rig on a branch named for the claimed
 bead, or detached (no trigger bead, or that branch is checked out in another
-worktree, WARN in the pre_start log): if `git branch --show-current` prints
+worktree; WARN in the pre_start log): if `git branch --show-current` prints
 nothing, create your branch in this directory before committing.
-
-If you start in the rig root and the rig forbids working there, create your
-own worktree outside it (`<city>/.worktrees/<rig>/<bead>`) from
-`origin/<default branch>`. If a branch named for the bead already exists,
-check that branch out in the new worktree instead of creating another.
 
 After the claim, compare the bead's `gc.work_branch` with your branch and
 restamp it when they differ (older `gc` builds stamp the rig root's branch).

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -2400,13 +2400,16 @@ class FormulaAssetTests(unittest.TestCase):
             "do-work-item/implement-item.md",
             "implementation-base/implement.md",
             "implementation-item-base/implement-item.md",
-            "build-basic-review/{target}.acceptance-review.md",
-            "build-basic-review/{target}.simplicity-review.md",
-            "build-basic-review/{target}.test-evidence-review.md",
             "build-basic-review/{target}.apply-review-findings.md",
         ):
             with self.subTest(switching_step=relative_path):
                 self.assertIn(relative_path, spans_by_file)
+        # Round 6 (gate r5): the review lanes are READERS and never switch onto
+        # the branch at all; their detach at the recorded commit is pinned in
+        # test_lane_handoff_lifecycle_holds_while_writing_and_releases_on_handoff.
+        for relative_path in self.LIFECYCLE_READERS:
+            with self.subTest(reader_never_switches_onto_branch=relative_path):
+                self.assertNotIn(relative_path, spans_by_file)
         # The steps that EDIT in the lane say what the flag protects and how
         # the refusal is handled; the boundary test comes before the switch.
         for relative_path in (
@@ -2458,7 +2461,7 @@ class FormulaAssetTests(unittest.TestCase):
                 "as a branch and a commit id",
                 '`git -C "$GC_DIR" log -1 <commit>`',
                 '`git -C "$GC_DIR" show <commit>:<path>`',
-                "put your own lane on the recorded branch first exactly as `do-work/implement` does for the lane case",
+                "inspect the recorded commit DETACHED in your own lane",
                 "write an iterate finding against review setup instead of entering it",
             ),
             "build-basic-review/{target}.simplicity-review.md": (
@@ -2486,6 +2489,148 @@ class FormulaAssetTests(unittest.TestCase):
             for clause in clauses:
                 with self.subTest(asset=relative_path, clause=clause):
                     self.assertIn(clause, flat)
+
+    # Round 6 (gate r5). Round 5 had every review lane put its OWN lane on
+    # `<gc.work_branch>` to run proof commands, but git allows one worktree
+    # per branch: the implementation lane still held it after implement, so
+    # the reviewer's switch failed ("already checked out at ..."), three
+    # parallel reviewers would have contended for it, and the fix lane was
+    # blocked the same way. The static rows could not see a worktree
+    # LIFECYCLE; these rows pin the sentences, and
+    # test_lane_lifecycle.py runs the same commands in real worktrees.
+    LIFECYCLE_WRITERS = (
+        "do-work/implement.md",
+        "do-work-item/implement-item.md",
+        "implementation-base/implement.md",
+        "implementation-item-base/implement-item.md",
+        "build-basic-review/{target}.apply-review-findings.md",
+    )
+    LIFECYCLE_READERS = (
+        "build-basic-review/{target}.acceptance-review.md",
+        "build-basic-review/{target}.simplicity-review.md",
+        "build-basic-review/{target}.test-evidence-review.md",
+    )
+
+    def test_lane_handoff_lifecycle_holds_while_writing_and_releases_on_handoff(self) -> None:
+        """One lifecycle, stated once in prepare-worktree's contract paragraph
+        and applied by every step: a lane HOLDS the item's branch only while
+        writing and RELEASES it (`switch --detach`) on handoff; every reader
+        INSPECTS the recorded commit detached; the fix lane takes then releases
+        the branch and fails closed naming a holder; recovery is the operator
+        releasing the holder's lane; close-source-anchor is unchanged."""
+        root = pathlib.Path(__file__).resolve().parents[1]
+        workflows = root / "assets" / "workflows"
+
+        def flat(relative_path: str) -> str:
+            return " ".join((workflows / relative_path).read_text(encoding="utf-8").split())
+
+        release_clause = (
+            "After the final commit and BEFORE closing this step with `gc.outcome=pass`, "
+            'release the branch from your lane: `git -C "$GC_DIR" switch --detach`'
+        )
+        verify_clause = '`git -C "$GC_DIR" branch --show-current` prints nothing'
+
+        # The contract, stated once.
+        prepare = flat("do-work/prepare-worktree.md")
+        step4 = prepare[prepare.index("4. Check the workspace") : prepare.index("5. Create or reuse")]
+        for clause in (
+            "under one lifecycle, because git allows one worktree per branch",
+            "a lane HOLDS the item's branch only while it is writing to it and RELEASES it when it hands off",
+            "every reader INSPECTS the recorded commit detached, never on the branch",
+            "every writer releases the branch the same way when it hands off",
+            "never takes the branch",
+            "`git switch --detach --no-overwrite-ignore <commit>`",
+            "Readers detached at one commit never contend",
+            "A writer that crashed before releasing leaves the branch held",
+            "already checked out at <path>",
+            "`git worktree list`",
+            "`git -C <holder lane> switch --detach`",
+            "already used by worktree at <path>",
+            "A step never enters another agent's lane and never releases it",
+        ):
+            with self.subTest(contract=clause):
+                self.assertIn(clause, step4)
+
+        # Rule 1: every WRITER releases after its commit and before its close.
+        for relative_path in self.LIFECYCLE_WRITERS:
+            text = flat(relative_path)
+            with self.subTest(writer=relative_path):
+                self.assertIn(release_clause, text)
+                self.assertIn(verify_clause, text)
+                self.assertIn("name the commit id in this step's close reason", text)
+                self.assertIn("HOLDS the item's branch only while it is writing to it", text)
+                self.assertIn("one worktree per branch", text)
+                take_at = text.index('switch --no-overwrite-ignore "<gc.work_branch>"')
+                release_at = text.index(release_clause)
+                self.assertLess(take_at, release_at, "the release comes after the take")
+                # The release is a detach of the OWN lane, never a force or a stash.
+                self.assertNotIn("switch --detach --force", text)
+                self.assertNotIn("git stash", text)
+
+        # Rule 2: every READER detaches at the recorded commit and never takes the branch.
+        for relative_path in self.LIFECYCLE_READERS:
+            text = flat(relative_path)
+            with self.subTest(reader=relative_path):
+                self.assertIn('`git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>`', text)
+                self.assertIn('`git -C "$GC_DIR" rev-parse "<gc.work_branch>"`', text)
+                self.assertIn("fail closed when git refuses", text)
+                self.assertIn("A review lane never takes the branch itself", text)
+                self.assertIn("never contend", text)
+                self.assertNotIn('switch "<gc.work_branch>"', text)
+                self.assertNotIn('switch --no-overwrite-ignore "<gc.work_branch>"', text)
+                self.assertNotIn("put your own lane on the recorded branch", text)
+                self.assertNotIn("switch --detach`", text)  # a reader releases nothing: it held nothing
+
+        # Rule 3: the fix lane names the holder-of-the-branch failure.
+        fix = flat("build-basic-review/{target}.apply-review-findings.md")
+        for clause in (
+            "second WRITER in the item's lifecycle",
+            "The branch is free when you arrive because the implementation lane released it on handoff",
+            "Take it only when there is a fix to commit",
+            "If the switch fails because another worktree still holds the branch",
+            "already checked out at <path>",
+            "already used by worktree at <path>",
+            "`git worktree list` names the holder",
+            "fail this step closed with the holder's path in the close reason and mail the mayor",
+            "`git -C <holder lane> switch --detach`",
+            "Never enter that lane, never `--force`, never remove its checkout, never release another agent's lane",
+        ):
+            with self.subTest(fix_lane=clause):
+                self.assertIn(clause, fix)
+        boundary_at = fix.index("rev-parse --show-toplevel")
+        take_at = fix.index('switch --no-overwrite-ignore "<gc.work_branch>"')
+        holder_at = fix.index("If the switch fails because another worktree still holds the branch")
+        release_at = fix.index(release_clause)
+        self.assertLess(boundary_at, take_at)
+        self.assertLess(take_at, holder_at)
+        self.assertLess(holder_at, release_at)
+
+        # Rule 5: close-source-anchor still verifies by branch and takes nothing.
+        close = flat("do-work/close-source-anchor.md")
+        self.assertIn('`git -C "$GC_DIR" log -1 <gc.work_branch>`', close)
+        self.assertNotIn("switch", close)
+
+        # README: the lifecycle in the Worker workspaces section.
+        readme = " ".join((root / "README.md").read_text(encoding="utf-8").split())
+        section = readme[readme.index("## Worker workspaces") : readme.index("## Build Methodology Contract")]
+        for clause in (
+            "a lane holds the item's branch only while it is writing to it and releases it (`git switch --detach`) when it hands off",
+            "every reader inspects the recorded commit detached in its own lane",
+            "the fix lane finds the branch free",
+            "released by the operator from that lane, never by another agent's step",
+        ):
+            with self.subTest(readme=clause):
+                self.assertIn(clause, section)
+
+        # The real-git companion exists and covers both scenarios.
+        lifecycle = (root / "tests" / "test_lane_lifecycle.py").read_text(encoding="utf-8")
+        for name in (
+            "test_hold_while_writing_release_on_handoff_inspect_detached",
+            "test_writer_that_did_not_release_blocks_the_fix_lane_with_the_holder_named",
+            "test_detach_at_commit_refuses_to_overwrite_an_ignored_file",
+        ):
+            with self.subTest(lifecycle_test=name):
+                self.assertIn(f"def {name}(", lifecycle)
 
     def test_build_artifact_prompts_use_set_metadata_for_paths(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -2208,7 +2208,15 @@ class FormulaAssetTests(unittest.TestCase):
         agent. implement (implementation worker) works in its own lane on that
         branch and never enters another agent's lane; close-source-anchor
         verifies by branch. The rig-root steps stay word for word
-        (test_do_work_formula_requires_persisted_item_worktree)."""
+        (test_do_work_formula_requires_persisted_item_worktree).
+
+        Round 4 (gate r3 M1): `--is-inside-work-tree` and `branch
+        --show-current` both succeed from any SUBDIRECTORY of the rig checkout,
+        so a work_dir inside the human checkout passed the round-3 lane test and
+        `switch --detach` would have detached the human checkout's HEAD. Both
+        steps now run a three-part boundary test (resolved top-level equals
+        `$GC_DIR`; not the rig root nor inside it; `--git-common-dir` is the
+        rig's) BEFORE recording the branch, detaching, or switching."""
         root = pathlib.Path(__file__).resolve().parents[1]
         rows = {
             "assets/workflows/do-work/prepare-worktree.md": (
@@ -2217,7 +2225,18 @@ class FormulaAssetTests(unittest.TestCase):
                 '`git -C "$GC_DIR" branch --show-current` prints a branch name',
                 "or the `pre_start` log says so",
                 "and `$GC_DIR` is not the rig root",
+                "this MAY be the lane case",
+                "Prove it with the boundary test below before recording a branch or detaching anything",
+                "a subdirectory of a human checkout must never be detached",
                 "this step creates nothing and hands no directory to anyone",
+                'The canonical git top-level of `$GC_DIR` IS `$GC_DIR`: `git -C "$GC_DIR" rev-parse --show-toplevel`, resolved, equals `$GC_DIR`, resolved',
+                "A subdirectory of any checkout fails this",
+                "That top-level is NOT the rig root and is NOT inside the rig root",
+                "a prefix match of the resolved rig root path plus a path separator",
+                '`git -C "$GC_DIR" rev-parse --git-common-dir`, resolved, is the same directory as the rig root\'s `.git`',
+                "A worktree of another repository fails this",
+                "When any part fails, this is NOT the lane case: record no branch, run no `switch` in `$GC_DIR`, detach nothing",
+                "continue with step 5 exactly as before",
                 "the item's BRANCH is the handoff",
                 'BRANCH="$(git -C "$GC_DIR" branch --show-current)"',
                 'create it from HEAD with `git -C "$GC_DIR" branch "$BRANCH" HEAD`',
@@ -2231,6 +2250,12 @@ class FormulaAssetTests(unittest.TestCase):
                 "When the source anchor has no `work_dir` and records `gc.work_branch`",
                 "your own `$GC_DIR` is the worktree",
                 "a lane your `pre_start` put on the item's branch (the branch recorded by `prepare-worktree`); work there",
+                "Prove it before editing, and before any `switch`, with the boundary test `prepare-worktree` step 4 applies",
+                '`git -C "$GC_DIR" rev-parse --show-toplevel` equals `$GC_DIR` itself',
+                "neither the rig root (`gc.work_dir` on the workflow root bead) nor inside the rig root",
+                '`git -C "$GC_DIR" rev-parse --git-common-dir` is the rig root\'s `.git`',
+                "fail this step before editing and never run `switch` there",
+                "switching a subdirectory of the rig checkout would switch the human checkout's branch",
                 'switch your own lane onto the recorded branch with `git -C "$GC_DIR" switch "<gc.work_branch>"`',
                 "if git refuses, or the branch is missing from the repository, fail this step before editing",
                 "Never enter another agent's lane",
@@ -2266,6 +2291,28 @@ class FormulaAssetTests(unittest.TestCase):
             prepare,
         )
         self.assertNotIn("When `work_dir` equals `$GC_DIR`", flat_by_path["assets/workflows/do-work/implement.md"])
+
+        # Round 4 (gate r3 M1): the three-part boundary test comes BEFORE the
+        # branch is recorded and BEFORE the detach in step 4, and BEFORE the
+        # switch in implement's lane paragraph. A subdirectory of the human
+        # checkout passes the two round-3 probes; it must never be detached or
+        # switched.
+        record_at = step4.index("--set-metadata gc.work_branch=")
+        detach_at = step4.index("switch --detach")
+        for probe in ("rev-parse --show-toplevel", "NOT inside the rig root", "rev-parse --git-common-dir"):
+            with self.subTest(step4_probe=probe):
+                self.assertLess(step4.index(probe), record_at)
+                self.assertLess(step4.index(probe), detach_at)
+        implement = flat_by_path["assets/workflows/do-work/implement.md"]
+        lane = implement[
+            implement.index("When the source anchor has no `work_dir`") : implement.index(
+                "Otherwise the steps below apply unchanged"
+            )
+        ]
+        switch_at = lane.index('switch "<gc.work_branch>"')
+        for probe in ("rev-parse --show-toplevel", "nor inside the rig root", "rev-parse --git-common-dir"):
+            with self.subTest(implement_probe=probe):
+                self.assertLess(lane.index(probe), switch_at)
 
     def test_build_artifact_prompts_use_set_metadata_for_paths(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -2256,8 +2256,8 @@ class FormulaAssetTests(unittest.TestCase):
                 '`git -C "$GC_DIR" rev-parse --git-common-dir` is the rig root\'s `.git`',
                 "fail this step before editing and never run `switch` there",
                 "switching a subdirectory of the rig checkout would switch the human checkout's branch",
-                'switch your own lane onto the recorded branch with `git -C "$GC_DIR" switch "<gc.work_branch>"`',
-                "if git refuses, or the branch is missing from the repository, fail this step before editing",
+                'switch your own lane onto the recorded branch with `git -C "$GC_DIR" switch --no-overwrite-ignore "<gc.work_branch>"`',
+                "If git refuses, for that or any other reason, or the branch is missing from the repository, fail this step before editing",
                 "Never enter another agent's lane",
                 "never treat a persisted `work_dir` that points into `.worktrees/<rig>/lane-*` of another agent as yours",
                 "Otherwise the steps below apply unchanged",
@@ -2309,10 +2309,183 @@ class FormulaAssetTests(unittest.TestCase):
                 "Otherwise the steps below apply unchanged"
             )
         ]
-        switch_at = lane.index('switch "<gc.work_branch>"')
+        switch_at = lane.index('switch --no-overwrite-ignore "<gc.work_branch>"')
         for probe in ("rev-parse --show-toplevel", "nor inside the rig root", "rev-parse --git-common-dir"):
             with self.subTest(implement_probe=probe):
                 self.assertLess(lane.index(probe), switch_at)
+
+    # Round 5 (gate r4). The lane case is ONE contract carried by EVERY step
+    # that reads the source anchor's work_dir, not by the two steps a gate
+    # happened to name: rounds 3 and 4 each fixed the readers the gate found
+    # and the next gate found the next reader (implement.md line 45 and the
+    # review setup still required a directory). These rows are grep-driven so
+    # a consumer added later without the clause fails here.
+    WORK_DIR_READERS_WITH_LANE_CLAUSE = (
+        "do-work/prepare-worktree.md",
+        "do-work/implement.md",
+        "do-work/close-source-anchor.md",
+        "do-work-item/implement-item.md",
+        "implementation-base/implement.md",
+        "implementation-item-base/implement-item.md",
+        "build-basic-review/{target}.setup-build-basic-review.md",
+        "build-basic-review/{target}.acceptance-review.md",
+        "build-basic-review/{target}.simplicity-review.md",
+        "build-basic-review/{target}.test-evidence-review.md",
+        "build-basic-review/{target}.apply-review-findings.md",
+    )
+
+    @staticmethod
+    def _work_dir_readers(workflows: pathlib.Path) -> dict[str, str]:
+        """Every workflow step whose text reads the source anchor's `work_dir`.
+        `gc.work_dir` is the launcher rig root (a different key) and is excluded;
+        `metadata.work_dir` and `work_dir=` are the same key and count."""
+        readers = {}
+        for path in sorted(workflows.rglob("*.md")):
+            text = path.read_text(encoding="utf-8")
+            if re.search(r"(?<!gc\.)\bwork_dir\b", text):
+                readers[path.relative_to(workflows).as_posix()] = " ".join(text.split())
+        return readers
+
+    def test_every_work_dir_reader_carries_the_lane_clause(self) -> None:
+        """Gate r4 finding 1: prepare-worktree in a lane records `gc.work_branch`
+        and persists no `work_dir`, so every reader of `work_dir` must resolve
+        that case in its OWN lane (switch its lane onto the branch to work, or
+        read the branch's commit to inspect) and must fail closed on a
+        `work_dir` naming an agent lane. The marker is the pair `gc.work_branch`
+        + "no `work_dir`"; the reader list below is the floor, found by grep,
+        not a ceiling."""
+        workflows = pathlib.Path(__file__).resolve().parents[1] / "assets" / "workflows"
+        readers = self._work_dir_readers(workflows)
+        missing = set(self.WORK_DIR_READERS_WITH_LANE_CLAUSE) - set(readers)
+        self.assertEqual(missing, set(), f"expected work_dir readers vanished: {sorted(missing)}")
+        for relative_path, flat in readers.items():
+            with self.subTest(reader=relative_path):
+                self.assertIn("`gc.work_branch`", flat)
+                self.assertIn("no `work_dir`", flat)
+                self.assertRegex(flat, r"(?i)never enters? another agent's (lane|directory)")
+                self.assertRegex(flat, r"lane-\*|own lane|OWN lane")
+        # The four `gc.work_dir`-only steps read the launcher rig root for the
+        # artifact validator and are NOT source-anchor work_dir readers.
+        for relative_path in (
+            "build-base/summarize-implementation.md",
+            "implement/summarize.md",
+        ):
+            with self.subTest(launcher_root_only=relative_path):
+                self.assertNotIn(relative_path, readers)
+                self.assertIn("`gc.work_dir`", (workflows / relative_path).read_text(encoding="utf-8"))
+
+    def test_every_lane_switch_refuses_to_overwrite_ignored_files(self) -> None:
+        """Gate r4 finding 2: a plain `git switch` onto the recorded branch
+        silently overwrites an ignored file in the lane that the branch tracks.
+        Every switch onto `<gc.work_branch>` in every workflow step carries
+        `--no-overwrite-ignore` and the step fails on the refusal (never
+        `--force`, never a stash, never removing the file), as
+        `worker-worktree.sh` already does in switch_worktree."""
+        root = pathlib.Path(__file__).resolve().parents[1]
+        workflows = root / "assets" / "workflows"
+        spans_by_file: dict[str, list[str]] = {}
+        for path in sorted(workflows.rglob("*.md")):
+            flat = " ".join(path.read_text(encoding="utf-8").split())
+            spans = [s for s in re.findall(r"`[^`]*`", flat) if "switch" in s and "<gc.work_branch>" in s]
+            if spans:
+                spans_by_file[path.relative_to(workflows).as_posix()] = spans
+        for relative_path, spans in spans_by_file.items():
+            for span in spans:
+                with self.subTest(asset=relative_path, span=span):
+                    self.assertIn("--no-overwrite-ignore", span)
+                    self.assertNotIn("--force", span)
+        for relative_path in (
+            "do-work/prepare-worktree.md",
+            "do-work/implement.md",
+            "do-work-item/implement-item.md",
+            "implementation-base/implement.md",
+            "implementation-item-base/implement-item.md",
+            "build-basic-review/{target}.acceptance-review.md",
+            "build-basic-review/{target}.simplicity-review.md",
+            "build-basic-review/{target}.test-evidence-review.md",
+            "build-basic-review/{target}.apply-review-findings.md",
+        ):
+            with self.subTest(switching_step=relative_path):
+                self.assertIn(relative_path, spans_by_file)
+        # The steps that EDIT in the lane say what the flag protects and how
+        # the refusal is handled; the boundary test comes before the switch.
+        for relative_path in (
+            "do-work/implement.md",
+            "do-work-item/implement-item.md",
+            "implementation-base/implement.md",
+            "implementation-item-base/implement-item.md",
+            "build-basic-review/{target}.apply-review-findings.md",
+        ):
+            flat = " ".join((workflows / relative_path).read_text(encoding="utf-8").split())
+            with self.subTest(editing_step=relative_path):
+                self.assertRegex(flat, r"ignored file in your lane .*collid")
+                self.assertIn("never `--force`", flat)
+                self.assertIn("never a stash", flat)
+                self.assertRegex(flat, r"never remove the colliding file")
+                switch_at = flat.index('switch --no-overwrite-ignore "<gc.work_branch>"')
+                for probe in ("rev-parse --show-toplevel", "rev-parse --git-common-dir"):
+                    self.assertLess(flat.index(probe), switch_at, probe)
+        script = (root / "assets" / "scripts" / "worker-worktree.sh").read_text(encoding="utf-8")
+        self.assertIn('git -C "$WORKDIR" switch --quiet --no-overwrite-ignore "$TARGET"', script)
+
+    def test_review_setup_records_branch_and_commit_when_work_dir_is_absent(self) -> None:
+        """Gate r4 finding 1, the review half: setup-build-basic-review wrote the
+        source anchor's `work_dir` into the review context, so the review and
+        fix lanes of the default separate-drain build had no workspace after a
+        lane handoff. It now records the BRANCH and the COMMIT id instead,
+        read from its own lane, and the lanes resolve those in their own
+        lanes; a `work_dir` naming an agent lane fails the setup bead."""
+        workflows = pathlib.Path(__file__).resolve().parents[1] / "assets" / "workflows"
+        setup = " ".join(
+            (workflows / "build-basic-review/{target}.setup-build-basic-review.md").read_text(encoding="utf-8").split()
+        )
+        for clause in (
+            "Include the source anchor id, its `work_dir`, changed files, commit id, and proof commands in the context",
+            "When the source anchor has no `work_dir` and records `gc.work_branch`",
+            "record the BRANCH (`gc.work_branch`) and the COMMIT id",
+            '`git -C "$GC_DIR" rev-parse "<gc.work_branch>"`, read from your own lane',
+            "in the context in place of a directory",
+            "the review and fix lanes resolve those in their own lanes",
+            "a persisted `work_dir` that names an agent lane (`.worktrees/<rig>/lane-*`) is invalid",
+            "a recorded branch that is missing from the repository",
+            "close this setup bead with `gc.outcome=fail`",
+        ):
+            with self.subTest(clause=clause):
+                self.assertIn(clause, setup)
+        # The consumers read the branch + commit, from their own lanes.
+        for relative_path, clauses in {
+            "build-basic-review/{target}.acceptance-review.md": (
+                "as a branch and a commit id",
+                '`git -C "$GC_DIR" log -1 <commit>`',
+                '`git -C "$GC_DIR" show <commit>:<path>`',
+                "put your own lane on the recorded branch first exactly as `do-work/implement` does for the lane case",
+                "write an iterate finding against review setup instead of entering it",
+            ),
+            "build-basic-review/{target}.simplicity-review.md": (
+                "the recorded branch and commit read from your OWN lane",
+                '`git -C "$GC_DIR" show <commit>:<path>`',
+            ),
+            "build-basic-review/{target}.test-evidence-review.md": (
+                "the recorded branch and commit read from your OWN lane",
+                '`git -C "$GC_DIR" show <commit>:<path>`',
+            ),
+            "build-basic-review/{target}.apply-review-findings.md": (
+                "When the review context records a branch and a commit instead of a `work_dir`",
+                "the workspace for fixes is your OWN lane, `$GC_DIR`, put on that branch exactly as `do-work/implement` does for the lane case",
+                "commit the fix on that branch",
+            ),
+            "do-work/implement.md": (
+                "use only its `work_dir` metadata as `WORKTREE`, or, when it has no `work_dir` and records `gc.work_branch`, your own lane `$GC_DIR` on that branch",
+            ),
+            "do-work/prepare-worktree.md": (
+                "The source anchor then has no `work_dir` and records `gc.work_branch`, and every later step that reads `work_dir`",
+                "resolves that case in its OWN lane",
+            ),
+        }.items():
+            flat = " ".join((workflows / relative_path).read_text(encoding="utf-8").split())
+            for clause in clauses:
+                with self.subTest(asset=relative_path, clause=clause):
+                    self.assertIn(clause, flat)
 
     def test_build_artifact_prompts_use_set_metadata_for_paths(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -2630,6 +2630,7 @@ class FormulaAssetTests(unittest.TestCase):
             "test_detach_at_commit_refuses_to_overwrite_an_ignored_file",
             "test_fix_lane_refreshes_the_recorded_commit_so_the_next_attempt_reviews_the_fix",
             "test_reviewer_in_the_rig_root_never_detaches_the_human_checkout",
+            "test_role_without_a_lane_in_a_rig_without_a_remote_gets_a_workspace_from_the_rig_head",
         ):
             with self.subTest(lifecycle_test=name):
                 self.assertIn(f"def {name}(", lifecycle)

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -2443,7 +2443,7 @@ class FormulaAssetTests(unittest.TestCase):
             (workflows / "build-basic-review/{target}.setup-build-basic-review.md").read_text(encoding="utf-8").split()
         )
         for clause in (
-            "Include the source anchor id, its `work_dir`, changed files, commit id, and proof commands in the context",
+            "Include, per source anchor, its id, its `work_dir`, changed files, commit id, and proof commands in the context",
             "When the source anchor has no `work_dir` and records `gc.work_branch`",
             "record the BRANCH (`gc.work_branch`) and the COMMIT id",
             '`git -C "$GC_DIR" rev-parse "<gc.work_branch>"`, read from your own lane',
@@ -2630,7 +2630,8 @@ class FormulaAssetTests(unittest.TestCase):
             "test_detach_at_commit_refuses_to_overwrite_an_ignored_file",
             "test_fix_lane_refreshes_the_recorded_commit_so_the_next_attempt_reviews_the_fix",
             "test_reviewer_in_the_rig_root_never_detaches_the_human_checkout",
-            "test_role_without_a_lane_in_a_rig_without_a_remote_gets_a_workspace_from_the_rig_head",
+            "test_role_session_without_a_lane_reads_detached_creates_no_worktree_and_moves_nothing",
+            "test_two_source_anchors_keep_their_own_review_commits_when_one_is_fixed",
         ):
             with self.subTest(lifecycle_test=name):
                 self.assertIn(f"def {name}(", lifecycle)
@@ -2644,16 +2645,25 @@ class FormulaAssetTests(unittest.TestCase):
     # would have moved the human checkout's HEAD. Both rows below are
     # grep-driven over the whole workflows tree (DO-NOT 218), and
     # test_lane_lifecycle.py runs both scenarios in real worktrees.
-    REVIEW_COMMIT_KEY = "gc.build.review_commit"
+    REVIEW_COMMIT_KEY = "gc.review_commit"
+    # Round 7's key lived on the workflow root; round 9 (gate r8 MAJOR) removed
+    # it. Spelled in two halves so this constant is not itself a hit.
+    ROOT_REVIEW_COMMIT_KEY = "gc.build." + "review_commit"
 
     def test_review_context_is_refreshed_after_a_fix_and_readers_read_the_current_commit(self) -> None:
-        """Gate r6 M1: the fix lane rewrites the commit id in the review
-        context file and records `gc.build.review_commit` on the workflow root
-        after its fix commit and BEFORE it releases the branch; the setup
-        writes the same key on its first run; every reader reads the key
-        first and falls back to the context file's commit. Grep-driven: every
+        """Gate r6 M1, reshaped by gate r8 MAJOR: the review commit is recorded
+        PER SOURCE ANCHOR (`gc.review_commit` on the anchor, and the anchor's
+        own record in the context file), never workflow-wide, because separate
+        drains produce several source anchors on independent branches and one
+        key would send every reader to one item's revision and let a fix on
+        one item overwrite the others'. The fix lane rewrites the record and
+        key of the anchor it committed on, after its fix commit and BEFORE it
+        releases the branch, and touches no other anchor's; the setup writes
+        each anchor's key on its first run; every reader reads its anchor's
+        key first and falls back to that anchor's record. Grep-driven: every
         workflow step that commits against a recorded review context carries
-        the refresh."""
+        the refresh, nothing writes the key on the workflow root, and the old
+        workflow-wide key is gone from the tree (no dual path)."""
         root = pathlib.Path(__file__).resolve().parents[1]
         workflows = root / "assets" / "workflows"
 
@@ -2661,31 +2671,42 @@ class FormulaAssetTests(unittest.TestCase):
             return " ".join((workflows / relative_path).read_text(encoding="utf-8").split())
 
         key = self.REVIEW_COMMIT_KEY
-        # The setup writes the key on first run and says why (it runs once).
+        # The setup writes the key per anchor on first run and says why (it runs once).
         setup = flat("build-basic-review/{target}.setup-build-basic-review.md")
         for clause in (
-            f"`gc bd update \"<workflow-root-id>\" --set-metadata '{key}=<commit>'`",
+            "The context carries one record PER SOURCE ANCHOR",
+            "the commit each record carries is recorded on that source anchor, never on the workflow root",
+            f"`gc bd update \"<source-anchor-id>\" --set-metadata '{key}=<commit>'`",
+            "once per source anchor the context names",
+            "the original drain member, never the synthetic convoy",
+            "There is no workflow-wide review commit",
             "This setup runs ONCE, outside the review loop",
-            f"the review lanes read `{key}` first and fall back to the context file's commit",
-            "the fix lane refreshes both the context file and this key after every fix commit",
-            "reviews the CURRENT commit, never the one this step saw",
-            f"only after the review context path and `{key}` are recorded",
+            f"the review lanes read each source anchor's `{key}` first and fall back to that anchor's record in the context file",
+            "the fix lane refreshes that anchor's record and key after every fix commit",
+            "reviews the CURRENT commit of each item, never the one this step saw",
+            f"only after the review context path is recorded on the workflow root and `{key}` is recorded on every source anchor the context names",
         ):
             with self.subTest(setup=clause):
                 self.assertIn(clause, setup)
 
         # The fix lane refreshes AFTER the fix commit and BEFORE the release,
-        # in the context file AND on the root, and states the retry sequence.
+        # in ITS anchor's record AND on ITS anchor and no other, and states
+        # the retry sequence.
         fix = flat("build-basic-review/{target}.apply-review-findings.md")
         for clause in (
             "Refresh the review context after the fix commit and BEFORE releasing the branch",
             "The review setup ran ONCE, outside the review loop",
             "review the ORIGINAL code and repeat the findings you just resolved until the attempts run out",
-            "Rewrite the commit id (and the changed-file list, when the context carries one) in the review context file at `gc.build.code_review_context_path`",
-            f"`gc bd update \"<workflow-root-id>\" --set-metadata '{key}=<sha>'`",
+            "The record is PER SOURCE ANCHOR",
+            "rewrite the commit id (and the changed-file list, when the context carries one) in the record of the source anchor you committed on, in the review context file at `gc.build.code_review_context_path`",
+            f"`gc bd update \"<source-anchor-id>\" --set-metadata '{key}=<sha>'`",
+            "the review lanes read that anchor's key first and fall back to that anchor's record in the context file",
+            "Touch no other source anchor's record or key",
+            "there is no workflow-wide review commit to update",
             "The retry sequence is: fix, commit, refresh the context, release the branch; then the loop re-runs the reviewers on the new commit",
             "Never leave the old commit in the context after a fix",
             "The refresh applies in the `work_dir` case too",
+            "the commit id in the context and on the source anchor are rewritten the same way",
         ):
             with self.subTest(fix_lane=clause):
                 self.assertIn(clause, fix)
@@ -2699,35 +2720,53 @@ class FormulaAssetTests(unittest.TestCase):
         self.assertLess(refresh_at, key_at)
         self.assertLess(key_at, release_at, "the refresh comes before the release")
 
-        # Every reader reads the key first and falls back to the context.
+        # Every reader reads ITS anchor's key first and falls back to that
+        # anchor's record; none reads the workflow root for it.
         for relative_path in self.LIFECYCLE_READERS:
             text = flat(relative_path)
             with self.subTest(reader=relative_path):
+                self.assertIn("one record per source anchor", text)
                 self.assertIn("Read the CURRENT commit first", text)
-                self.assertIn(f"`{key}` on the workflow root bead", text)
-                self.assertRegex(text, r"fall back to the (commit in the )?review context file")
+                self.assertIn(f"`{key}` on that source anchor bead", text)
+                self.assertIn("`gc bd show <source-anchor-id> --json`", text)
+                self.assertRegex(text, r"fall back to (the commit in )?that anchor's record in the review context file")
                 self.assertIn("only when that key is absent", text)
+                self.assertIn("no workflow-wide review commit", text)
                 self.assertRegex(text, r"(?i)the (review )?loop re-runs this lane after a fix")
                 read_at = text.index("Read the CURRENT commit first")
                 detach_at = text.index('`git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>`')
                 self.assertLess(read_at, detach_at, "the current commit is read before the detach")
+                self.assertNotIn(f"`{key}` on the workflow root", text)
+                self.assertNotIn("<workflow-root-id>", text)
 
-        # The contract paragraph names the refresh as part of the lifecycle.
+        # The contract paragraph names the per-anchor refresh as part of the lifecycle.
         prepare = flat("do-work/prepare-worktree.md")
         step4 = prepare[prepare.index("4. Check the workspace") : prepare.index("5. Create or reuse")]
         self.assertIn("A writer that commits after a commit was recorded for readers", step4)
-        self.assertIn(f"the review context file and `{key}` on the workflow root", step4)
+        self.assertIn(
+            f"this source anchor's record in the review context file and `{key}` on this source anchor", step4
+        )
+        self.assertIn("per item, never a workflow-wide key", step4)
         self.assertIn("never the one the setup saw", step4)
+        self.assertIn("no other item's recorded commit moves", step4)
 
         # Grep-driven: every workflow step that names the review context AND
-        # commits code carries the refresh; every step that names the key is
-        # the setup (writes), a reader (reads first) or the fix lane
-        # (refreshes), or the contract that states the lifecycle.
+        # commits code carries the per-anchor refresh; every step that names
+        # the key is the setup (writes), a reader (reads first) or the fix
+        # lane (refreshes), or the contract that states the lifecycle; no step
+        # writes the key on the workflow root; and the old workflow-wide key
+        # is gone from every step, the README and the role fragment (no dual
+        # path).
         writers_against_a_context = []
         key_holders = []
+        old_key = self.ROOT_REVIEW_COMMIT_KEY
+        root_write = re.compile(r"<workflow-root-id>\"? --set-metadata '?" + re.escape(key) + "=")
         for path in sorted(workflows.rglob("*.md")):
             text = " ".join(path.read_text(encoding="utf-8").split())
             rel = path.relative_to(workflows).as_posix()
+            with self.subTest(no_dual_path=rel):
+                self.assertNotIn(old_key, text)
+                self.assertNotRegex(text, root_write)
             if key in text:
                 key_holders.append(rel)
             # A step COMMITS when it names the git action (readers only speak of
@@ -2735,7 +2774,8 @@ class FormulaAssetTests(unittest.TestCase):
             if "review context" in text and re.search(r"commit the fix on|`git commit`", text):
                 writers_against_a_context.append(rel)
                 with self.subTest(writer_against_context=rel):
-                    self.assertIn(f"--set-metadata '{key}=<sha>'", text)
+                    self.assertIn(f"\"<source-anchor-id>\" --set-metadata '{key}=<sha>'", text)
+                    self.assertIn("Touch no other source anchor's record or key", text)
                     self.assertIn("Never leave the old commit in the context after a fix", text)
         self.assertEqual(writers_against_a_context, ["build-basic-review/{target}.apply-review-findings.md"])
         self.assertEqual(
@@ -2749,13 +2789,18 @@ class FormulaAssetTests(unittest.TestCase):
                 + self.LIFECYCLE_READERS
             ),
         )
+        for relative_path in ("README.md", "template-fragments/gc-role-worker.template.md"):
+            with self.subTest(no_dual_path=relative_path):
+                self.assertNotIn(old_key, (root / relative_path).read_text(encoding="utf-8"))
 
         readme = " ".join((root / "README.md").read_text(encoding="utf-8").split())
         section = readme[readme.index("## Worker workspaces") : readme.index("## Build Methodology Contract")]
         self.assertIn(
-            f"After the fix lane commits it refreshes the recorded commit (the review context file and `{key}` on the workflow root) before it releases the branch",
+            "After the fix lane commits it refreshes the recorded commit of the item it fixed (that source "
+            f"anchor's record in the review context file and `{key}` on that source anchor, never a workflow-wide key",
             section,
         )
+        self.assertIn("the other items' recorded commits stay as they were", section)
 
     def test_every_switch_or_detach_in_the_workflows_tree_is_preceded_by_the_boundary_test(self) -> None:
         """Gate r6 M2: a reviewer role with no configured `work_dir` starts in

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -2628,9 +2628,238 @@ class FormulaAssetTests(unittest.TestCase):
             "test_hold_while_writing_release_on_handoff_inspect_detached",
             "test_writer_that_did_not_release_blocks_the_fix_lane_with_the_holder_named",
             "test_detach_at_commit_refuses_to_overwrite_an_ignored_file",
+            "test_fix_lane_refreshes_the_recorded_commit_so_the_next_attempt_reviews_the_fix",
+            "test_reviewer_in_the_rig_root_never_detaches_the_human_checkout",
         ):
             with self.subTest(lifecycle_test=name):
                 self.assertIn(f"def {name}(", lifecycle)
+
+    # Round 7 (gate r6). Two findings, both about the review loop's second
+    # and later attempts: (M1) the review setup runs ONCE, outside the loop,
+    # and recorded the commit the reviewers inspect, so after a fix every
+    # later attempt re-reviewed the ORIGINAL code; (M2) the review lanes
+    # detached `$GC_DIR` without the boundary test the writers apply, and a
+    # reviewer role with no `work_dir` starts in the RIG ROOT, so that detach
+    # would have moved the human checkout's HEAD. Both rows below are
+    # grep-driven over the whole workflows tree (DO-NOT 218), and
+    # test_lane_lifecycle.py runs both scenarios in real worktrees.
+    REVIEW_COMMIT_KEY = "gc.build.review_commit"
+
+    def test_review_context_is_refreshed_after_a_fix_and_readers_read_the_current_commit(self) -> None:
+        """Gate r6 M1: the fix lane rewrites the commit id in the review
+        context file and records `gc.build.review_commit` on the workflow root
+        after its fix commit and BEFORE it releases the branch; the setup
+        writes the same key on its first run; every reader reads the key
+        first and falls back to the context file's commit. Grep-driven: every
+        workflow step that commits against a recorded review context carries
+        the refresh."""
+        root = pathlib.Path(__file__).resolve().parents[1]
+        workflows = root / "assets" / "workflows"
+
+        def flat(relative_path: str) -> str:
+            return " ".join((workflows / relative_path).read_text(encoding="utf-8").split())
+
+        key = self.REVIEW_COMMIT_KEY
+        # The setup writes the key on first run and says why (it runs once).
+        setup = flat("build-basic-review/{target}.setup-build-basic-review.md")
+        for clause in (
+            f"`gc bd update \"<workflow-root-id>\" --set-metadata '{key}=<commit>'`",
+            "This setup runs ONCE, outside the review loop",
+            f"the review lanes read `{key}` first and fall back to the context file's commit",
+            "the fix lane refreshes both the context file and this key after every fix commit",
+            "reviews the CURRENT commit, never the one this step saw",
+            f"only after the review context path and `{key}` are recorded",
+        ):
+            with self.subTest(setup=clause):
+                self.assertIn(clause, setup)
+
+        # The fix lane refreshes AFTER the fix commit and BEFORE the release,
+        # in the context file AND on the root, and states the retry sequence.
+        fix = flat("build-basic-review/{target}.apply-review-findings.md")
+        for clause in (
+            "Refresh the review context after the fix commit and BEFORE releasing the branch",
+            "The review setup ran ONCE, outside the review loop",
+            "review the ORIGINAL code and repeat the findings you just resolved until the attempts run out",
+            "Rewrite the commit id (and the changed-file list, when the context carries one) in the review context file at `gc.build.code_review_context_path`",
+            f"`gc bd update \"<workflow-root-id>\" --set-metadata '{key}=<sha>'`",
+            "The retry sequence is: fix, commit, refresh the context, release the branch; then the loop re-runs the reviewers on the new commit",
+            "Never leave the old commit in the context after a fix",
+            "The refresh applies in the `work_dir` case too",
+        ):
+            with self.subTest(fix_lane=clause):
+                self.assertIn(clause, fix)
+        commit_at = fix.index("commit the fix on that branch")
+        refresh_at = fix.index("Refresh the review context after the fix commit")
+        key_at = fix.index(f"--set-metadata '{key}=<sha>'")
+        release_at = fix.index(
+            "After the final commit and BEFORE closing this step with `gc.outcome=pass`, release the branch"
+        )
+        self.assertLess(commit_at, refresh_at, "the refresh comes after the fix commit")
+        self.assertLess(refresh_at, key_at)
+        self.assertLess(key_at, release_at, "the refresh comes before the release")
+
+        # Every reader reads the key first and falls back to the context.
+        for relative_path in self.LIFECYCLE_READERS:
+            text = flat(relative_path)
+            with self.subTest(reader=relative_path):
+                self.assertIn("Read the CURRENT commit first", text)
+                self.assertIn(f"`{key}` on the workflow root bead", text)
+                self.assertRegex(text, r"fall back to the (commit in the )?review context file")
+                self.assertIn("only when that key is absent", text)
+                self.assertRegex(text, r"(?i)the (review )?loop re-runs this lane after a fix")
+                read_at = text.index("Read the CURRENT commit first")
+                detach_at = text.index('`git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>`')
+                self.assertLess(read_at, detach_at, "the current commit is read before the detach")
+
+        # The contract paragraph names the refresh as part of the lifecycle.
+        prepare = flat("do-work/prepare-worktree.md")
+        step4 = prepare[prepare.index("4. Check the workspace") : prepare.index("5. Create or reuse")]
+        self.assertIn("A writer that commits after a commit was recorded for readers", step4)
+        self.assertIn(f"the review context file and `{key}` on the workflow root", step4)
+        self.assertIn("never the one the setup saw", step4)
+
+        # Grep-driven: every workflow step that names the review context AND
+        # commits code carries the refresh; every step that names the key is
+        # the setup (writes), a reader (reads first) or the fix lane
+        # (refreshes), or the contract that states the lifecycle.
+        writers_against_a_context = []
+        key_holders = []
+        for path in sorted(workflows.rglob("*.md")):
+            text = " ".join(path.read_text(encoding="utf-8").split())
+            rel = path.relative_to(workflows).as_posix()
+            if key in text:
+                key_holders.append(rel)
+            # A step COMMITS when it names the git action (readers only speak of
+            # "the fix commit" as a noun and commit nothing).
+            if "review context" in text and re.search(r"commit the fix on|`git commit`", text):
+                writers_against_a_context.append(rel)
+                with self.subTest(writer_against_context=rel):
+                    self.assertIn(f"--set-metadata '{key}=<sha>'", text)
+                    self.assertIn("Never leave the old commit in the context after a fix", text)
+        self.assertEqual(writers_against_a_context, ["build-basic-review/{target}.apply-review-findings.md"])
+        self.assertEqual(
+            sorted(key_holders),
+            sorted(
+                (
+                    "do-work/prepare-worktree.md",
+                    "build-basic-review/{target}.setup-build-basic-review.md",
+                    "build-basic-review/{target}.apply-review-findings.md",
+                )
+                + self.LIFECYCLE_READERS
+            ),
+        )
+
+        readme = " ".join((root / "README.md").read_text(encoding="utf-8").split())
+        section = readme[readme.index("## Worker workspaces") : readme.index("## Build Methodology Contract")]
+        self.assertIn(
+            f"After the fix lane commits it refreshes the recorded commit (the review context file and `{key}` on the workflow root) before it releases the branch",
+            section,
+        )
+
+    def test_every_switch_or_detach_in_the_workflows_tree_is_preceded_by_the_boundary_test(self) -> None:
+        """Gate r6 M2: a reviewer role with no configured `work_dir` starts in
+        the RIG ROOT (the human checkout), and the round-6 reader clause ran
+        `switch --detach --no-overwrite-ignore <commit>` in `$GC_DIR` with no
+        boundary test, which would have moved the human checkout's HEAD.
+        Grep-driven over the whole workflows tree: every backticked span that
+        switches or detaches comes AFTER the three-part boundary test in its
+        file and the file says what happens when a part fails; every reader
+        names the rig-root case and the "no lane for this role" failure and,
+        failing the test, inspects by `git show`/`git log` only."""
+        root = pathlib.Path(__file__).resolve().parents[1]
+        workflows = root / "assets" / "workflows"
+        probes = ("rev-parse --show-toplevel", "rev-parse --git-common-dir")
+        switching_files: dict[str, list[str]] = {}
+        for path in sorted(workflows.rglob("*.md")):
+            flat = " ".join(path.read_text(encoding="utf-8").split())
+            # Command spans only: a span that RUNS git (`git ... switch`,
+            # `git switch --detach ...`, `git worktree add ... --detach`), not
+            # the prose mention `switch` in "before any `switch`".
+            spans = [
+                s for s in re.findall(r"`[^`]*`", flat)
+                if re.search(r"\bgit\b", s) and re.search(r"\bswitch\b|--detach|\bcheckout\b", s)
+            ]
+            if not spans:
+                continue
+            rel = path.relative_to(workflows).as_posix()
+            switching_files[rel] = spans
+            with self.subTest(asset=rel):
+                self.assertRegex(flat, r"(?i)when any part fails")
+                for probe in probes:
+                    self.assertIn(probe, flat)
+            for span in spans:
+                with self.subTest(asset=rel, span=span):
+                    self.assertNotIn("--force", span)
+                    self.assertNotIn("git checkout", span)  # switch is the only checkout verb in the tree
+                    span_at = flat.index(span)
+                    for probe in probes:
+                        self.assertLess(flat.index(probe), span_at, f"{probe} must come before {span}")
+        # The floor, found by grep: the contract, the five writers, the three readers.
+        for relative_path in ("do-work/prepare-worktree.md",) + self.LIFECYCLE_WRITERS + self.LIFECYCLE_READERS:
+            with self.subTest(switching_file=relative_path):
+                self.assertIn(relative_path, switching_files)
+        # Nothing else in the tree switches, detaches or checks out.
+        self.assertEqual(
+            sorted(switching_files),
+            sorted(("do-work/prepare-worktree.md",) + self.LIFECYCLE_WRITERS + self.LIFECYCLE_READERS),
+        )
+
+        # Every reader: boundary test before its detach; the rig-root case is
+        # named; failing the test it detaches nothing, inspects by git
+        # show/log only, and fails closed "no lane for this role" naming the fix.
+        for relative_path in self.LIFECYCLE_READERS:
+            flat = " ".join((workflows / relative_path).read_text(encoding="utf-8").split())
+            with self.subTest(reader=relative_path):
+                detach_at = flat.index('`git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>`')
+                boundary_at = flat.index("boundary test `do-work/prepare-worktree` step 4 applies")
+                self.assertLess(boundary_at, detach_at)
+                for probe in probes:
+                    self.assertLess(flat.index(probe), detach_at)
+                self.assertRegex(flat, r"prove the lane FIRST, before any `switch` or detach")
+                self.assertIn("starts in the RIG ROOT, the human checkout", flat)
+                self.assertRegex(flat, r"(?i)switch(es)? and detach(es)? nothing")
+                self.assertIn("moves the human checkout's HEAD", flat)
+                self.assertIn('`git -C "$GC_DIR" show <commit>:<path>` and `git -C "$GC_DIR" log -1 <commit>` only', flat)
+                self.assertIn("`gc.outcome=fail`, `gc.failure_class=no-lane`", flat)
+                self.assertIn('"no lane for this role"', flat)
+                self.assertIn("a `work_dir` for this role (README, Worker workspaces)", flat)
+                self.assertIn("Only when all three parts hold:", flat)
+                self.assertLess(flat.index("Only when all three parts hold:"), detach_at)
+                # A reader still releases nothing and never takes the branch (round 6).
+                self.assertNotIn("switch --detach`", flat)
+                self.assertNotIn('switch --no-overwrite-ignore "<gc.work_branch>"', flat)
+
+        # The fix lane's release sits inside the guarded lane case.
+        fix = " ".join(
+            (workflows / "build-basic-review/{target}.apply-review-findings.md").read_text(encoding="utf-8").split()
+        )
+        release_at = fix.index('release the branch from your lane: `git -C "$GC_DIR" switch --detach`')
+        for probe in probes:
+            self.assertLess(fix.index(probe), release_at)
+        for clause in (
+            "This release is inside the guarded lane case above",
+            "only after the boundary test passed and your switch onto the branch succeeded",
+            "was never switched and detaches nothing",
+            "a detach there would move the human checkout's HEAD",
+            "the per-item worktree is already detached and shared with no one, so there is nothing to release",
+        ):
+            with self.subTest(fix_release=clause):
+                self.assertIn(clause, fix)
+
+        # The contract paragraph: readers apply the same boundary test.
+        prepare = " ".join((workflows / "do-work/prepare-worktree.md").read_text(encoding="utf-8").split())
+        step4 = prepare[prepare.index("4. Check the workspace") : prepare.index("5. Create or reuse")]
+        self.assertIn("after the same boundary test above that every writer applies", step4)
+        self.assertIn("detaches nothing and reads by `git show` and `git log` only", step4)
+
+        readme = " ".join((root / "README.md").read_text(encoding="utf-8").split())
+        section = readme[readme.index("## Worker workspaces") : readme.index("## Build Methodology Contract")]
+        for clause in (
+            "Every lane, writer or reader, proves it is a lane before it switches or detaches anything",
+            "a reader there reads by `git show` only and never detaches the human checkout",
+        ):
+            with self.subTest(readme=clause):
+                self.assertIn(clause, section)
 
     def test_build_artifact_prompts_use_set_metadata_for_paths(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -2199,6 +2199,36 @@ class FormulaAssetTests(unittest.TestCase):
 
         self.assertIn("do not patch the launcher root", apply)
         self.assertIn("source anchor and implementation\nworktree", synthesize)
+
+    def test_do_work_worktree_steps_are_no_ops_in_a_gc_lane(self) -> None:
+        """When gc started the session in an agent lane (work_dir + pre_start),
+        prepare-worktree creates nothing and implement works in $GC_DIR; the
+        original steps stay for a session that started in the rig root."""
+        root = pathlib.Path(__file__).resolve().parents[1]
+        rows = {
+            "assets/workflows/do-work/prepare-worktree.md": (
+                "When `$GC_DIR` is already a git worktree of the rig on a branch",
+                '`git -C "$GC_DIR" rev-parse --is-inside-work-tree` prints `true`',
+                '`git -C "$GC_DIR" branch --show-current` prints a branch name',
+                "or the `pre_start` log says so",
+                "and `$GC_DIR` is not the rig root",
+                'this step creates nothing: set `WORKTREE="$GC_DIR"`',
+                "Otherwise (the session started in the rig root; the role has no lane)",
+                "Create or reuse a deterministic git worktree at",
+            ),
+            "assets/workflows/do-work/implement.md": (
+                "When `work_dir` equals `$GC_DIR`",
+                "there is nothing to switch into: work in `$GC_DIR`",
+                "Otherwise the steps below apply unchanged",
+                'then `cd "$WORKTREE"` before reading or editing source files',
+            ),
+        }
+        for relative_path, clauses in rows.items():
+            flat = " ".join((root / relative_path).read_text(encoding="utf-8").split())
+            for clause in clauses:
+                with self.subTest(asset=relative_path, clause=clause):
+                    self.assertIn(clause, flat)
+
     def test_build_artifact_prompts_use_set_metadata_for_paths(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]
         path_contracts = {

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -2200,10 +2200,15 @@ class FormulaAssetTests(unittest.TestCase):
         self.assertIn("do not patch the launcher root", apply)
         self.assertIn("source anchor and implementation\nworktree", synthesize)
 
-    def test_do_work_worktree_steps_are_no_ops_in_a_gc_lane(self) -> None:
+    def test_do_work_lane_case_hands_over_the_branch_never_the_directory(self) -> None:
         """When gc started the session in an agent lane (work_dir + pre_start),
-        prepare-worktree creates nothing and implement works in $GC_DIR; the
-        original steps stay for a session that started in the rig root."""
+        prepare-worktree (run operator) records the item's BRANCH on the source
+        anchor and detaches its own lane from it; it never persists a work_dir,
+        because a lane is per agent and a directory is never handed to another
+        agent. implement (implementation worker) works in its own lane on that
+        branch and never enters another agent's lane; close-source-anchor
+        verifies by branch. The rig-root steps stay word for word
+        (test_do_work_formula_requires_persisted_item_worktree)."""
         root = pathlib.Path(__file__).resolve().parents[1]
         rows = {
             "assets/workflows/do-work/prepare-worktree.md": (
@@ -2212,22 +2217,55 @@ class FormulaAssetTests(unittest.TestCase):
                 '`git -C "$GC_DIR" branch --show-current` prints a branch name',
                 "or the `pre_start` log says so",
                 "and `$GC_DIR` is not the rig root",
-                'this step creates nothing: set `WORKTREE="$GC_DIR"`',
+                "this step creates nothing and hands no directory to anyone",
+                "the item's BRANCH is the handoff",
+                'BRANCH="$(git -C "$GC_DIR" branch --show-current)"',
+                'create it from HEAD with `git -C "$GC_DIR" branch "$BRANCH" HEAD`',
+                "gc bd update <source-anchor-id> --set-metadata gc.work_branch=<branch>",
+                'Detach this lane from the branch with `git -C "$GC_DIR" switch --detach`',
+                "Do NOT persist `work_dir` in the lane case: step 6 is skipped",
                 "Otherwise (the session started in the rig root; the role has no lane)",
                 "Create or reuse a deterministic git worktree at",
             ),
             "assets/workflows/do-work/implement.md": (
-                "When `work_dir` equals `$GC_DIR`",
-                "there is nothing to switch into: work in `$GC_DIR`",
+                "When the source anchor has no `work_dir` and records `gc.work_branch`",
+                "your own `$GC_DIR` is the worktree",
+                "a lane your `pre_start` put on the item's branch (the branch recorded by `prepare-worktree`); work there",
+                'switch your own lane onto the recorded branch with `git -C "$GC_DIR" switch "<gc.work_branch>"`',
+                "if git refuses, or the branch is missing from the repository, fail this step before editing",
+                "Never enter another agent's lane",
+                "never treat a persisted `work_dir` that points into `.worktrees/<rig>/lane-*` of another agent as yours",
                 "Otherwise the steps below apply unchanged",
                 'then `cd "$WORKTREE"` before reading or editing source files',
             ),
+            "assets/workflows/do-work/close-source-anchor.md": (
+                "When the source anchor has no `work_dir` and records `gc.work_branch`",
+                'verify from your own lane instead: `git -C "$GC_DIR" log -1 <gc.work_branch>`',
+                "Never enter another agent's lane to verify",
+            ),
+        }
+        flat_by_path = {
+            relative_path: " ".join((root / relative_path).read_text(encoding="utf-8").split())
+            for relative_path in rows
         }
         for relative_path, clauses in rows.items():
-            flat = " ".join((root / relative_path).read_text(encoding="utf-8").split())
             for clause in clauses:
                 with self.subTest(asset=relative_path, clause=clause):
-                    self.assertIn(clause, flat)
+                    self.assertIn(clause, flat_by_path[relative_path])
+
+        # The lane case (step 4) never persists a directory: the work_dir stamp
+        # lives only in the rig-root path (step 6), and the round-2 shape that
+        # recorded the operator's lane as the item worktree is gone from both files.
+        prepare = flat_by_path["assets/workflows/do-work/prepare-worktree.md"]
+        step4 = prepare[prepare.index("4. Check the workspace") : prepare.index("5. Create or reuse")]
+        self.assertNotIn("work_dir=", step4)
+        self.assertNotIn('WORKTREE="$GC_DIR"', step4)
+        self.assertIn(
+            "6. Persist the absolute path on the source anchor with "
+            "`gc bd update <source-anchor-id> --set-metadata work_dir=<absolute worktree path>`",
+            prepare,
+        )
+        self.assertNotIn("When `work_dir` equals `$GC_DIR`", flat_by_path["assets/workflows/do-work/implement.md"])
 
     def test_build_artifact_prompts_use_set_metadata_for_paths(self) -> None:
         root = pathlib.Path(__file__).resolve().parents[1]

--- a/gascity/tests/test_lane_lifecycle.py
+++ b/gascity/tests/test_lane_lifecycle.py
@@ -26,6 +26,14 @@ Round 7 (codex gate r6) adds two rules the loop's LATER attempts depend on:
    no `work_dir` starts in the RIG ROOT (the human checkout), fails the test,
    detaches nothing, and inspects by `git show`/`git log` only.
 
+Round 8 (codex gate r7) adds the rule for a role the city gave no lane:
+
+8. the Workspace fallback (a role whose `$GC_DIR` is the rig root) RESOLVES
+   the base of its new branch in worker-worktree.sh's order, `<remote>/HEAD`,
+   `<remote>/main`, `<remote>/master` for the rig's remote whatever its name,
+   else the rig checkout's HEAD, so a rig with no remote still yields a
+   workspace, and the rig checkout's HEAD never moves.
+
 Every step below runs the exact git commands the formula text names, in real
 worktrees under a temporary directory, with no network. The static rows in
 test_formula_assets pin the sentences; this file pins that the sentences work.
@@ -209,6 +217,41 @@ class Rig:
             stderr=subprocess.PIPE,
             text=True,
         )
+
+
+    # --- round 8: the Workspace fallback for a role with no lane -------------
+
+    @staticmethod
+    def fallback_resolves_base(rig_root: pathlib.Path) -> tuple[str, str]:
+        """The role prompt's Workspace fallback, as the paragraph orders it
+        (the order worker-worktree.sh uses): the rig's remote, `origin` or its
+        other name, fetched, then `<remote>/HEAD`, `<remote>/main`,
+        `<remote>/master`; else the rig checkout's current HEAD. The base is
+        pinned to a commit in the rig. Returns (base, commit)."""
+        remotes = out(rig_root, "remote").split()
+        remote = "origin" if "origin" in remotes else (remotes[0] if remotes else None)
+        base = "HEAD"
+        if remote is not None:
+            git(rig_root, "fetch", "--quiet", remote, check=False)
+            head = git(rig_root, "symbolic-ref", "--quiet", "--short", f"refs/remotes/{remote}/HEAD", check=False)
+            if head.returncode == 0:
+                base = head.stdout.strip()
+            elif git(rig_root, "show-ref", "--verify", "--quiet", f"refs/remotes/{remote}/main", check=False).returncode == 0:
+                base = f"{remote}/main"
+            elif git(rig_root, "show-ref", "--verify", "--quiet", f"refs/remotes/{remote}/master", check=False).returncode == 0:
+                base = f"{remote}/master"
+        commit_id = out(rig_root, "rev-parse", "--verify", "--quiet", f"{base}^{{commit}}")
+        return base, commit_id
+
+    def fallback_creates_workspace(self, bead: str) -> pathlib.Path:
+        """The fallback's create step: `<city>/.worktrees/<rig>/<bead>` on a
+        new branch named for the bead, from the pinned commit, registered
+        from the rig root (reads refs there, never its working tree)."""
+        _base, commit_id = self.fallback_resolves_base(self.rig)
+        path = self.lanes_root / bead
+        path.parent.mkdir(parents=True, exist_ok=True)
+        git(self.rig, "worktree", "add", "--quiet", "-b", bead, str(path), commit_id)
+        return path
 
 
 class LaneLifecycleTests(unittest.TestCase):
@@ -503,3 +546,50 @@ class LaneLifecycleTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+    def test_role_without_a_lane_in_a_rig_without_a_remote_gets_a_workspace_from_the_rig_head(self) -> None:
+        """Round 8 (gate r7): a role the city gave no work_dir starts in the rig
+        root and takes the Workspace fallback. This rig has NO remote, so the
+        round-7 text's `origin/<default branch>` does not exist; the resolution
+        the paragraph now documents ends at the rig checkout's HEAD, the
+        worker creates `<city>/.worktrees/<rig>/<bead>` from that commit,
+        works there, and the rig checkout's branch, HEAD and status never
+        move. A remote not named origin is then found by the same order."""
+        rig = self.rig
+        self.assertEqual(out(rig.rig, "remote"), "")
+        for ref in ("origin/HEAD", "origin/main", "origin/master"):
+            with self.subTest(missing=ref):
+                self.assertNotEqual(git(rig.rig, "rev-parse", "--verify", "--quiet", ref, check=False).returncode, 0)
+        # $GC_DIR is the rig root: the boundary test fails (part 2), so this is
+        # the fallback, not the lane case, and nothing is switched there.
+        self.assertEqual(Rig.boundary_test(rig.rig, rig.rig), (True, False, True))
+
+        base, commit_id = Rig.fallback_resolves_base(rig.rig)
+        self.assertEqual((base, commit_id), ("HEAD", rig.main_sha))
+
+        bead = "gp-nolane1"
+        self.assertNotEqual(git(rig.rig, "rev-parse", "--verify", "--quiet", f"refs/heads/{bead}", check=False).returncode, 0)
+        workspace = rig.fallback_creates_workspace(bead)
+        self.assertEqual(workspace, rig.lanes_root / bead)
+        self.assertEqual(out(workspace, "branch", "--show-current"), bead)
+        self.assertEqual(out(workspace, "rev-parse", "HEAD"), rig.main_sha)
+        self.assertEqual(Rig.boundary_test(workspace, rig.rig), (True, True, True))
+        # The worker works there: a commit lands on the bead's branch, not on main.
+        done = commit(workspace, "work.txt", "done\n", "work in the fallback workspace")
+        self.assertEqual(out(rig.rig, "rev-parse", bead), done)
+        self.assertEqual(out(rig.rig, "rev-parse", "main"), rig.main_sha)
+        self.assert_rig_root_untouched()
+        self.assert_no_contention()
+
+        # The same order finds a remote that is not named origin: its default
+        # branch wins over the rig's HEAD, so the paragraph's first candidate
+        # is real, not only its last.
+        mirror = rig.root / "mirror.git"
+        subprocess.run(["git", "clone", "--quiet", "--bare", str(rig.rig), str(mirror)], check=True)
+        git(rig.rig, "remote", "add", "upstream", str(mirror))
+        git(rig.rig, "fetch", "--quiet", "upstream")
+        git(rig.rig, "remote", "set-head", "upstream", "--auto")
+        self.assertEqual(out(rig.rig, "remote"), "upstream")
+        base, commit_id = Rig.fallback_resolves_base(rig.rig)
+        self.assertEqual((base, commit_id), ("upstream/main", rig.main_sha))
+        self.assert_rig_root_untouched()

--- a/gascity/tests/test_lane_lifecycle.py
+++ b/gascity/tests/test_lane_lifecycle.py
@@ -14,6 +14,18 @@ text fixes one lifecycle (gp-0mvp round 6, codex gate r5):
    by another agent's step;
 5. close-source-anchor reads `git log -1 <branch>`.
 
+Round 7 (codex gate r6) adds two rules the loop's LATER attempts depend on:
+
+6. the review setup runs ONCE, outside the review loop, and records the commit
+   the readers inspect; the FIX lane refreshes that record (the context file
+   and `gc.build.review_commit` on the workflow root) after its commit and
+   before it releases, so the next attempt's readers inspect the fix, not the
+   original code;
+7. every lane, reader or writer, proves it is a lane with the three-part
+   boundary test before it switches or detaches anything; a reviewer role with
+   no `work_dir` starts in the RIG ROOT (the human checkout), fails the test,
+   detaches nothing, and inspects by `git show`/`git log` only.
+
 Every step below runs the exact git commands the formula text names, in real
 worktrees under a temporary directory, with no network. The static rows in
 test_formula_assets pin the sentences; this file pins that the sentences work.
@@ -121,6 +133,72 @@ class Rig:
         """Rule 1: after the final commit, before the close."""
         self.run(lane, "switch", "--detach")
         assert out(lane, "branch", "--show-current") == ""
+
+    # --- round 7: the recorded commit and the boundary test ------------------
+
+    def setup_records(self, lane: pathlib.Path, branch: str) -> tuple[pathlib.Path, dict[str, str]]:
+        """setup-build-basic-review, from ITS OWN lane: resolve the branch to a
+        commit, write it (and the changed files) into the review context file,
+        and record `gc.build.review_commit` on the workflow root (modelled as a
+        dict: the bead store is not part of this test)."""
+        commit_id = out(lane, "rev-parse", branch)
+        context = self.root / "artifacts" / "code-review-context.md"
+        context.parent.mkdir(parents=True, exist_ok=True)
+        changed = out(lane, "diff-tree", "--no-commit-id", "--name-only", "-r", commit_id)
+        context.write_text(
+            f"branch: {branch}\ncommit: {commit_id}\nchanged_files: {changed}\n",
+            encoding="utf-8",
+        )
+        root_metadata = {"gc.build.review_commit": commit_id}
+        return context, root_metadata
+
+    @staticmethod
+    def context_commit(context: pathlib.Path) -> str:
+        for line in context.read_text(encoding="utf-8").splitlines():
+            if line.startswith("commit: "):
+                return line[len("commit: "):]
+        raise AssertionError("no commit in the review context")
+
+    @staticmethod
+    def reader_reads_current_commit(context: pathlib.Path, root_metadata: dict[str, str]) -> str:
+        """A review lane: `gc.build.review_commit` on the workflow root first,
+        the context file's commit only when the key is absent."""
+        return root_metadata.get("gc.build.review_commit") or Rig.context_commit(context)
+
+    def fix_lane_refreshes(self, lane: pathlib.Path, context: pathlib.Path, root_metadata: dict[str, str]) -> str:
+        """apply-review-findings, after its fix commit and BEFORE the release:
+        rewrite the commit id and changed files in the context file, then record
+        the new commit on the workflow root."""
+        new_commit = out(lane, "rev-parse", "HEAD")
+        old_commit = self.context_commit(context)
+        changed = out(lane, "diff-tree", "--no-commit-id", "--name-only", "-r", new_commit)
+        text = context.read_text(encoding="utf-8").replace(f"commit: {old_commit}", f"commit: {new_commit}")
+        text = "\n".join(
+            f"changed_files: {changed}" if line.startswith("changed_files: ") else line
+            for line in text.splitlines()
+        ) + "\n"
+        context.write_text(text, encoding="utf-8")
+        root_metadata["gc.build.review_commit"] = new_commit
+        return new_commit
+
+    @staticmethod
+    def boundary_test(gc_dir: pathlib.Path, rig_root: pathlib.Path) -> tuple[bool, bool, bool]:
+        """prepare-worktree step 4, the three parts, every path resolved:
+        1. the top-level of $GC_DIR IS $GC_DIR; 2. it is neither the rig root
+        nor inside it; 3. its git common dir is the rig root's `.git`."""
+        gc_dir_resolved = gc_dir.resolve()
+        rig_resolved = rig_root.resolve()
+        toplevel = pathlib.Path(out(gc_dir, "rev-parse", "--show-toplevel")).resolve()
+        part1 = toplevel == gc_dir_resolved
+        part2 = toplevel != rig_resolved and not str(toplevel).startswith(str(rig_resolved) + "/")
+        common = pathlib.Path(out(gc_dir, "rev-parse", "--git-common-dir"))
+        if not common.is_absolute():
+            common = gc_dir / common
+        rig_common = pathlib.Path(out(rig_root, "rev-parse", "--git-common-dir"))
+        if not rig_common.is_absolute():
+            rig_common = rig_root / rig_common
+        part3 = common.resolve() == rig_common.resolve()
+        return part1, part2, part3
 
     def reader_detaches(self, lane: pathlib.Path, commit_id: str) -> subprocess.Popen[str]:
         """Rule 2: a review lane inspects the recorded commit detached; returned
@@ -282,6 +360,145 @@ class LaneLifecycleTests(unittest.TestCase):
         self.assertEqual(rig.snapshot(reviewer), before)
         self.assertEqual((reviewer / "build.out").read_text(encoding="utf-8"), "ignored local\n")
         self.assert_rig_root_untouched()
+
+    def test_fix_lane_refreshes_the_recorded_commit_so_the_next_attempt_reviews_the_fix(self) -> None:
+        """Rule 6 (gate r6 M1). The setup records commit A once; the fix lane
+        commits B and refreshes the context file and the root key BEFORE it
+        releases; a reader on the next attempt reads B (from the key first,
+        from the context when the key is absent), detaches at B, and sees the
+        fix. A is gone from the context. The rig root never changes."""
+        rig = self.rig
+        operator = rig.lane("run-operator")
+        implement = rig.lane("implementation-worker-1")
+        setup = rig.lane("run-operator-2")
+        reviewer_1 = rig.lane("implementation-reviewer-1")
+        fix = rig.lane("implementation-worker-2")
+        reviewer_2 = rig.lane("implementation-reviewer-2")
+
+        rig.operator_prepares(operator)
+        rig.writer_takes(implement)
+        commit_a = commit(implement, "feature.txt", "implemented\n", "implement")
+        rig.writer_releases(implement)
+
+        # setup-build-basic-review, ONCE, outside the loop: records A.
+        context, root_metadata = rig.setup_records(setup, ITEM_BRANCH)
+        self.assertEqual(rig.context_commit(context), commit_a)
+        self.assertEqual(root_metadata["gc.build.review_commit"], commit_a)
+        self.assertIn("changed_files: feature.txt", context.read_text(encoding="utf-8"))
+
+        # Attempt 1: a reader reads A, detaches at A, finds the defect.
+        current = rig.reader_reads_current_commit(context, root_metadata)
+        self.assertEqual(current, commit_a)
+        proc = rig.reader_detaches(reviewer_1, current)
+        _, err = proc.communicate(timeout=60)
+        self.assertEqual(proc.returncode, 0, err)
+        self.assertEqual(out(reviewer_1, "show", f"{current}:feature.txt"), "implemented")
+
+        # apply-review-findings: take, commit B, REFRESH, then release.
+        rig.writer_takes(fix)
+        commit_b = commit(fix, "feature.txt", "implemented\nfixed\n", "fix")
+        (fix / "feature_test.txt").write_text("proof\n", encoding="utf-8")
+        git(fix, "add", "feature_test.txt")
+        git(fix, "-c", "user.name=t", "-c", "user.email=t@example.invalid", "commit", "--quiet", "--amend", "--no-edit")
+        commit_b = out(fix, "rev-parse", "HEAD")
+        self.assertNotEqual(commit_b, commit_a)
+        refreshed = rig.fix_lane_refreshes(fix, context, root_metadata)
+        # The refresh happened while the fix lane still HOLDS the branch (before the release).
+        self.assertEqual(rig.holder_of(ITEM_BRANCH), str(fix))
+        self.assertEqual(refreshed, commit_b)
+        rig.writer_releases(fix)
+
+        # Never leave the old commit in the context after a fix.
+        context_text = context.read_text(encoding="utf-8")
+        self.assertNotIn(commit_a, context_text)
+        self.assertEqual(rig.context_commit(context), commit_b)
+        self.assertIn("changed_files: feature.txt feature_test.txt", " ".join(context_text.split()))
+        self.assertEqual(root_metadata["gc.build.review_commit"], commit_b)
+        self.assertEqual(out(operator, "log", "-1", "--format=%H", ITEM_BRANCH), commit_b)
+
+        # Attempt 2: a reader reads B, not A: from the key first ...
+        current = rig.reader_reads_current_commit(context, root_metadata)
+        self.assertEqual(current, commit_b)
+        # ... and from the context file when the key is absent.
+        self.assertEqual(rig.reader_reads_current_commit(context, {}), commit_b)
+        proc = rig.reader_detaches(reviewer_2, current)
+        _, err = proc.communicate(timeout=60)
+        self.assertEqual(proc.returncode, 0, err)
+        self.assertEqual(out(reviewer_2, "rev-parse", "HEAD"), commit_b)
+        self.assertEqual(out(reviewer_2, "show", f"{current}:feature.txt"), "implemented\nfixed")
+        self.assertEqual((reviewer_2 / "feature_test.txt").read_text(encoding="utf-8"), "proof\n")
+        # The round-6 shape (the stale commit) is what this rule removes: a
+        # reader at A would not have seen the fix at all.
+        self.assertEqual(out(reviewer_1, "show", f"{commit_a}:feature.txt"), "implemented")
+
+        self.assertIsNone(rig.holder_of(ITEM_BRANCH))
+        self.assert_no_contention()
+        self.assert_rig_root_untouched()
+
+    def test_reviewer_in_the_rig_root_never_detaches_the_human_checkout(self) -> None:
+        """Rule 7 (gate r6 M2). A reviewer role with no configured `work_dir`
+        starts in the RIG ROOT: `$GC_DIR` is the human checkout. The
+        three-part boundary test fails there (part 2), in a subdirectory of
+        the rig root (part 1) and in a worktree of another repository (part
+        3), and holds in a real lane. Failing it, the reader detaches NOTHING
+        and inspects by `git show <commit>:<path>` / `git log -1 <commit>`,
+        which work from any checkout of the rig's repository. Last, the
+        command the guard withholds is run once against the rig root to show
+        what it would have done: moved the human checkout's HEAD."""
+        rig = self.rig
+        operator = rig.lane("run-operator")
+        implement = rig.lane("implementation-worker-1")
+        lane_reviewer = rig.lane("implementation-reviewer-1")
+
+        rig.operator_prepares(operator)
+        rig.writer_takes(implement)
+        commit_a = commit(implement, "feature.txt", "implemented\n", "implement")
+        rig.writer_releases(implement)
+        recorded = out(implement, "rev-parse", ITEM_BRANCH)
+        self.assertEqual(recorded, commit_a)
+
+        # Positive proof: a real lane passes all three parts.
+        self.assertEqual(rig.boundary_test(lane_reviewer, rig.rig), (True, True, True))
+
+        # The rig root itself: part 2 fails (it IS the rig root).
+        rig_root_as_gc_dir = rig.rig
+        self.assertEqual(rig.boundary_test(rig_root_as_gc_dir, rig.rig), (True, False, True))
+        # A subdirectory of the human checkout: part 1 fails (and part 2).
+        subdir = rig.rig / "src"
+        subdir.mkdir()
+        self.assertEqual(rig.boundary_test(subdir, rig.rig)[:2], (False, False))
+        # A worktree of ANOTHER repository: parts 1 and 2 hold, part 3 fails.
+        other = rig.root / "other-repo"
+        subprocess.run(["git", "init", "--quiet", "-b", "main", str(other)], check=True)
+        commit(other, "x.txt", "x\n", "other")
+        self.assertEqual(rig.boundary_test(other, rig.rig), (True, True, False))
+
+        # The reviewer whose $GC_DIR is the rig root: the test fails, so it
+        # runs NO switch and NO detach there, and reads by show/log only.
+        parts = rig.boundary_test(rig_root_as_gc_dir, rig.rig)
+        self.assertFalse(all(parts))
+        before = rig.snapshot(rig_root_as_gc_dir)
+        self.assertEqual(out(rig_root_as_gc_dir, "show", f"{recorded}:feature.txt"), "implemented")
+        self.assertEqual(out(rig_root_as_gc_dir, "log", "-1", "--format=%H", recorded), recorded)
+        self.assertEqual(rig.snapshot(rig_root_as_gc_dir), before)
+        self.assertEqual(out(rig_root_as_gc_dir, "branch", "--show-current"), "main")
+        self.assertEqual(out(rig_root_as_gc_dir, "rev-parse", "HEAD"), rig.main_sha)
+        self.assert_rig_root_untouched()
+        # The lane reviewer, having passed, detaches at the commit as before.
+        proc = rig.reader_detaches(lane_reviewer, recorded)
+        _, err = proc.communicate(timeout=60)
+        self.assertEqual(proc.returncode, 0, err)
+        self.assertEqual(out(lane_reviewer, "rev-parse", "HEAD"), recorded)
+        self.assert_rig_root_untouched()
+
+        # What the guard withholds: the round-6 reader command, run in the rig
+        # root, detaches the human checkout and moves its HEAD off main.
+        proc = rig.reader_detaches(rig_root_as_gc_dir, recorded)
+        _, err = proc.communicate(timeout=60)
+        self.assertEqual(proc.returncode, 0, err)
+        self.assertEqual(out(rig_root_as_gc_dir, "branch", "--show-current"), "")
+        self.assertEqual(out(rig_root_as_gc_dir, "rev-parse", "HEAD"), recorded)
+        self.assertNotEqual(rig.snapshot(rig_root_as_gc_dir), rig.rig_before)
 
 
 if __name__ == "__main__":

--- a/gascity/tests/test_lane_lifecycle.py
+++ b/gascity/tests/test_lane_lifecycle.py
@@ -1,0 +1,288 @@
+"""Real-git test of the lane handoff lifecycle the formula text prescribes.
+
+The do-work and build-basic-review steps hand an item between agent lanes by
+BRANCH (a directory is per agent). git allows one worktree per branch, so the
+text fixes one lifecycle (gp-0mvp round 6, codex gate r5):
+
+1. a WRITER (implement, the review fix lane) holds the item's branch only while
+   writing and releases it with `git switch --detach` when it hands off;
+2. a READER (the review lanes) never takes the branch: it detaches its own lane
+   at the recorded commit, so parallel readers never contend;
+3. the FIX lane takes the branch, commits, releases it; when a holder still has
+   the branch it fails closed with the holder named and forces nothing;
+4. a crashed writer's branch is released from that lane by the operator, never
+   by another agent's step;
+5. close-source-anchor reads `git log -1 <branch>`.
+
+Every step below runs the exact git commands the formula text names, in real
+worktrees under a temporary directory, with no network. The static rows in
+test_formula_assets pin the sentences; this file pins that the sentences work.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+def git(cwd: pathlib.Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def out(cwd: pathlib.Path, *args: str) -> str:
+    return git(cwd, *args).stdout.strip()
+
+
+def commit(repo: pathlib.Path, name: str, content: str, message: str) -> str:
+    (repo / name).write_text(content, encoding="utf-8")
+    git(repo, "add", name)
+    git(
+        repo,
+        "-c", "user.name=t", "-c", "user.email=t@example.invalid",
+        "commit", "--quiet", "-m", message,
+    )
+    return out(repo, "rev-parse", "HEAD")
+
+
+ITEM_BRANCH = "gp-item1"
+
+
+class Rig:
+    """A rig checkout (the human's) plus per-role lanes as worktrees of it,
+    laid out the way the city's `work_dir = ".worktrees/{{.Rig}}/lane-..."`
+    patch does. Each lane starts on its own step branch, as `pre_start`
+    (worker-worktree.sh) leaves it: the step bead's branch, not the item's."""
+
+    def __init__(self, root: pathlib.Path) -> None:
+        self.root = root
+        self.rig = root / "rig"
+        self.lanes_root = root / ".worktrees" / "rig"
+        subprocess.run(["git", "init", "--quiet", "-b", "main", str(self.rig)], check=True)
+        self.main_sha = commit(self.rig, "README.md", "hello\n", "init")
+        self.rig_before = self.snapshot(self.rig)
+        self.stderr_seen: list[str] = []
+
+    def snapshot(self, checkout: pathlib.Path) -> tuple[str, str, str]:
+        return (
+            out(checkout, "branch", "--show-current"),
+            out(checkout, "rev-parse", "HEAD"),
+            out(checkout, "status", "--porcelain"),
+        )
+
+    def lane(self, role: str) -> pathlib.Path:
+        path = self.lanes_root / f"lane-gc.{role}"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # pre_start puts the lane on the STEP bead's branch, cut from HEAD.
+        git(self.rig, "worktree", "add", "--quiet", "-b", f"step-{role}", str(path), "main")
+        return path
+
+    def run(self, lane: pathlib.Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        proc = git(lane, *args, check=False)
+        self.stderr_seen.append(proc.stderr)
+        if check:
+            assert proc.returncode == 0, f"git {' '.join(args)} in {lane.name}: {proc.stderr}"
+        return proc
+
+    def holder_of(self, branch: str) -> str | None:
+        """The worktree path that has `branch` checked out, from
+        `git worktree list --porcelain` (the command the fix lane names)."""
+        current: str | None = None
+        for line in out(self.rig, "worktree", "list", "--porcelain").splitlines():
+            if line.startswith("worktree "):
+                current = line[len("worktree "):]
+            elif line == f"branch refs/heads/{branch}":
+                return current
+        return None
+
+    # --- the lifecycle steps, each the formula text's commands ---------------
+
+    def operator_prepares(self, lane: pathlib.Path) -> None:
+        """prepare-worktree step 4, lane case: create the item's branch from HEAD
+        (the lane was detached) and detach the lane from any branch."""
+        self.run(lane, "switch", "--detach")  # the operator's lane starts detached here
+        assert out(lane, "branch", "--show-current") == ""
+        self.run(lane, "branch", ITEM_BRANCH, "HEAD")
+        self.run(lane, "switch", "--detach")
+        assert out(lane, "rev-parse", "--verify", f"refs/heads/{ITEM_BRANCH}")
+        assert out(lane, "branch", "--show-current") == ""
+
+    def writer_takes(self, lane: pathlib.Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+        """implement / apply-review-findings: switch the OWN lane onto the branch."""
+        return self.run(lane, "switch", "--no-overwrite-ignore", ITEM_BRANCH, check=check)
+
+    def writer_releases(self, lane: pathlib.Path) -> None:
+        """Rule 1: after the final commit, before the close."""
+        self.run(lane, "switch", "--detach")
+        assert out(lane, "branch", "--show-current") == ""
+
+    def reader_detaches(self, lane: pathlib.Path, commit_id: str) -> subprocess.Popen[str]:
+        """Rule 2: a review lane inspects the recorded commit detached; returned
+        as a process so two readers can do it at the same time."""
+        return subprocess.Popen(
+            ["git", "-C", str(lane), "switch", "--detach", "--no-overwrite-ignore", commit_id],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+
+class LaneLifecycleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.rig = Rig(pathlib.Path(self._tmp.name).resolve())
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def assert_rig_root_untouched(self) -> None:
+        self.assertEqual(self.rig.snapshot(self.rig.rig), self.rig.rig_before)
+
+    def assert_no_contention(self) -> None:
+        for err in self.rig.stderr_seen:
+            self.assertNotIn("already checked out", err)
+            self.assertNotIn("already used by worktree", err)
+
+    def test_hold_while_writing_release_on_handoff_inspect_detached(self) -> None:
+        rig = self.rig
+        operator = rig.lane("run-operator")
+        implement = rig.lane("implementation-worker-1")
+        reviewer_a = rig.lane("implementation-reviewer-1")
+        reviewer_b = rig.lane("implementation-reviewer-2")
+        fix = rig.lane("implementation-worker-2")
+
+        # prepare-worktree (operator lane): the branch exists, the lane is detached.
+        rig.operator_prepares(operator)
+        self.assertEqual(out(operator, "branch", "--show-current"), "")
+
+        # implement (its own lane): take, commit, RELEASE (rule 1).
+        rig.writer_takes(implement)
+        self.assertEqual(out(implement, "branch", "--show-current"), ITEM_BRANCH)
+        impl_commit = commit(implement, "feature.txt", "implemented\n", "implement")
+        rig.writer_releases(implement)
+        self.assertEqual(out(implement, "rev-parse", "HEAD"), impl_commit)  # HEAD stays
+        self.assertIsNone(rig.holder_of(ITEM_BRANCH))  # the branch is free
+        self.assertEqual(out(operator, "branch", "--show-current"), "")
+
+        # close-source-anchor / review setup read the commit by branch (rule 5).
+        recorded = out(reviewer_a, "rev-parse", ITEM_BRANCH)
+        self.assertEqual(recorded, impl_commit)
+        self.assertEqual(out(reviewer_a, "log", "-1", "--format=%H", ITEM_BRANCH), impl_commit)
+
+        # TWO reviewers detach at the recorded commit at the same time (rule 2).
+        procs = [rig.reader_detaches(reviewer_a, recorded), rig.reader_detaches(reviewer_b, recorded)]
+        for proc in procs:
+            _, err = proc.communicate(timeout=60)
+            rig.stderr_seen.append(err)
+            self.assertEqual(proc.returncode, 0, err)
+        for reviewer in (reviewer_a, reviewer_b):
+            self.assertEqual(out(reviewer, "branch", "--show-current"), "")
+            self.assertEqual(out(reviewer, "rev-parse", "HEAD"), recorded)
+            self.assertEqual(out(reviewer, "show", f"{recorded}:feature.txt"), "implemented")
+            self.assertEqual((reviewer / "feature.txt").read_text(encoding="utf-8"), "implemented\n")
+        self.assertIsNone(rig.holder_of(ITEM_BRANCH))  # readers never took it
+        self.assertEqual(out(operator, "branch", "--show-current"), "")
+
+        # apply-review-findings (a third lane): the branch is free; take, commit, release (rule 3).
+        rig.writer_takes(fix)
+        self.assertEqual(rig.holder_of(ITEM_BRANCH), str(fix))
+        fix_commit = commit(fix, "feature.txt", "implemented\nfixed\n", "fix")
+        rig.writer_releases(fix)
+        self.assertIsNone(rig.holder_of(ITEM_BRANCH))
+
+        # The close reads the branch tip: the fix commit, on top of the implementation.
+        self.assertEqual(out(operator, "log", "-1", "--format=%H", ITEM_BRANCH), fix_commit)
+        self.assertEqual(out(operator, "rev-parse", f"{fix_commit}^"), impl_commit)
+        # Reviewers still sit at the commit they inspected; nothing moved under them.
+        for reviewer in (reviewer_a, reviewer_b):
+            self.assertEqual(out(reviewer, "rev-parse", "HEAD"), impl_commit)
+
+        self.assert_no_contention()
+        self.assertEqual(out(operator, "branch", "--show-current"), "")
+        self.assert_rig_root_untouched()
+
+    def test_writer_that_did_not_release_blocks_the_fix_lane_with_the_holder_named(self) -> None:
+        rig = self.rig
+        operator = rig.lane("run-operator")
+        implement = rig.lane("implementation-worker-1")
+        reviewer = rig.lane("implementation-reviewer-1")
+        fix = rig.lane("implementation-worker-2")
+
+        rig.operator_prepares(operator)
+        rig.writer_takes(implement)
+        impl_commit = commit(implement, "feature.txt", "implemented\n", "implement")
+        # ... and the implementation lane crashes before `switch --detach`.
+        self.assertEqual(rig.holder_of(ITEM_BRANCH), str(implement))
+
+        # A reader is unaffected: it never wanted the branch.
+        proc = rig.reader_detaches(reviewer, impl_commit)
+        _, err = proc.communicate(timeout=60)
+        self.assertEqual(proc.returncode, 0, err)
+        self.assertEqual(out(reviewer, "show", f"{impl_commit}:feature.txt"), "implemented")
+
+        # The fix lane's switch fails; git and `git worktree list` both name the holder.
+        fix_before = rig.snapshot(fix)
+        refused = rig.writer_takes(fix, check=False)
+        self.assertNotEqual(refused.returncode, 0)
+        # git < 2.45 says "already checked out at", newer says "already used by worktree at".
+        self.assertRegex(refused.stderr + refused.stdout, r"already (checked out|used by worktree) at")
+        self.assertIn(implement.name, refused.stderr + refused.stdout)
+        self.assertEqual(rig.holder_of(ITEM_BRANCH), str(implement))
+
+        # Nothing was forced: the fix lane is where it was, the holder still
+        # holds, the operator lane is still detached, the rig root untouched.
+        self.assertEqual(rig.snapshot(fix), fix_before)
+        self.assertEqual(out(implement, "branch", "--show-current"), ITEM_BRANCH)
+        self.assertEqual(out(implement, "rev-parse", "HEAD"), impl_commit)
+        self.assertEqual(out(operator, "branch", "--show-current"), "")
+        self.assert_rig_root_untouched()
+
+        # Rule 4: the operator releases the branch FROM THE HOLDER'S LANE; only
+        # then does the fix lane's own switch succeed.
+        rig.run(implement, "switch", "--detach")
+        self.assertIsNone(rig.holder_of(ITEM_BRANCH))
+        rig.writer_takes(fix)
+        self.assertEqual(rig.holder_of(ITEM_BRANCH), str(fix))
+        fix_commit = commit(fix, "feature.txt", "implemented\nfixed\n", "fix")
+        rig.writer_releases(fix)
+        self.assertEqual(out(operator, "log", "-1", "--format=%H", ITEM_BRANCH), fix_commit)
+        self.assert_rig_root_untouched()
+
+    def test_detach_at_commit_refuses_to_overwrite_an_ignored_file(self) -> None:
+        """The reader's `switch --detach --no-overwrite-ignore <commit>` keeps
+        the round-5 guarantee: an ignored file in the lane that the commit
+        tracks makes git refuse, and the lane is left as it was."""
+        rig = self.rig
+        operator = rig.lane("run-operator")
+        implement = rig.lane("implementation-worker-1")
+        reviewer = rig.lane("implementation-reviewer-1")
+
+        rig.operator_prepares(operator)
+        rig.writer_takes(implement)
+        impl_commit = commit(implement, "build.out", "tracked\n", "implement tracks a build output")
+        rig.writer_releases(implement)
+
+        (reviewer / "build.out").write_text("ignored local\n", encoding="utf-8")
+        info_exclude = pathlib.Path(out(reviewer, "rev-parse", "--git-path", "info/exclude"))
+        info_exclude.parent.mkdir(parents=True, exist_ok=True)
+        info_exclude.write_text("build.out\n", encoding="utf-8")
+        self.assertEqual(out(reviewer, "status", "--porcelain"), "")  # ignored, not untracked
+
+        before = rig.snapshot(reviewer)
+        proc = rig.reader_detaches(reviewer, impl_commit)
+        _, err = proc.communicate(timeout=60)
+        self.assertNotEqual(proc.returncode, 0, "git overwrote an ignored file")
+        self.assertIn("build.out", err)
+        self.assertEqual(rig.snapshot(reviewer), before)
+        self.assertEqual((reviewer / "build.out").read_text(encoding="utf-8"), "ignored local\n")
+        self.assert_rig_root_untouched()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gascity/tests/test_lane_lifecycle.py
+++ b/gascity/tests/test_lane_lifecycle.py
@@ -17,22 +17,27 @@ text fixes one lifecycle (gp-0mvp round 6, codex gate r5):
 Round 7 (codex gate r6) adds two rules the loop's LATER attempts depend on:
 
 6. the review setup runs ONCE, outside the review loop, and records the commit
-   the readers inspect; the FIX lane refreshes that record (the context file
-   and `gc.build.review_commit` on the workflow root) after its commit and
-   before it releases, so the next attempt's readers inspect the fix, not the
-   original code;
+   the readers inspect; the FIX lane refreshes that record after its commit
+   and before it releases, so the next attempt's readers inspect the fix, not
+   the original code;
 7. every lane, reader or writer, proves it is a lane with the three-part
    boundary test before it switches or detaches anything; a reviewer role with
    no `work_dir` starts in the RIG ROOT (the human checkout), fails the test,
    detaches nothing, and inspects by `git show`/`git log` only.
 
-Round 8 (codex gate r7) adds the rule for a role the city gave no lane:
+Round 9 (Afik, 9/9 22:28 CT: "drop the fallback if we don't use it"; codex
+gate r8) replaces round 8's lane-less workspace fallback and reshapes rule 6:
 
-8. the Workspace fallback (a role whose `$GC_DIR` is the rig root) RESOLVES
-   the base of its new branch in worker-worktree.sh's order, `<remote>/HEAD`,
-   `<remote>/main`, `<remote>/master` for the rig's remote whatever its name,
-   else the rig checkout's HEAD, so a rig with no remote still yields a
-   workspace, and the rig checkout's HEAD never moves.
+8. a role session outside a gc-made lane (a role the city gave no `work_dir`
+   starts in the rig root, the human checkout) has no lane: it creates no
+   worktree, creates and moves no branch, writes nothing into the rig
+   checkout, reads the item by `git show` / `git log -1` only, and a step
+   that needs a checkout closes `gc.outcome=fail`, `gc.failure_class=no-lane`;
+9. the review commit is recorded PER SOURCE ANCHOR (`gc.review_commit` on the
+   anchor, and the anchor's own record in the context file), never
+   workflow-wide: separate drains put several items on independent branches,
+   each inspected at its own commit, and a fix on one item leaves the others'
+   recorded commits as they were.
 
 Every step below runs the exact git commands the formula text names, in real
 worktrees under a temporary directory, with no network. The static rows in
@@ -123,19 +128,22 @@ class Rig:
 
     # --- the lifecycle steps, each the formula text's commands ---------------
 
-    def operator_prepares(self, lane: pathlib.Path) -> None:
+    def operator_prepares(self, lane: pathlib.Path, branch: str = ITEM_BRANCH) -> None:
         """prepare-worktree step 4, lane case: create the item's branch from HEAD
-        (the lane was detached) and detach the lane from any branch."""
+        (the lane was detached) and detach the lane from any branch. The
+        branch is named for the source anchor; one per drained item."""
         self.run(lane, "switch", "--detach")  # the operator's lane starts detached here
         assert out(lane, "branch", "--show-current") == ""
-        self.run(lane, "branch", ITEM_BRANCH, "HEAD")
+        self.run(lane, "branch", branch, "HEAD")
         self.run(lane, "switch", "--detach")
-        assert out(lane, "rev-parse", "--verify", f"refs/heads/{ITEM_BRANCH}")
+        assert out(lane, "rev-parse", "--verify", f"refs/heads/{branch}")
         assert out(lane, "branch", "--show-current") == ""
 
-    def writer_takes(self, lane: pathlib.Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    def writer_takes(
+        self, lane: pathlib.Path, branch: str = ITEM_BRANCH, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
         """implement / apply-review-findings: switch the OWN lane onto the branch."""
-        return self.run(lane, "switch", "--no-overwrite-ignore", ITEM_BRANCH, check=check)
+        return self.run(lane, "switch", "--no-overwrite-ignore", branch, check=check)
 
     def writer_releases(self, lane: pathlib.Path) -> None:
         """Rule 1: after the final commit, before the close."""
@@ -144,49 +152,76 @@ class Rig:
 
     # --- round 7: the recorded commit and the boundary test ------------------
 
-    def setup_records(self, lane: pathlib.Path, branch: str) -> tuple[pathlib.Path, dict[str, str]]:
-        """setup-build-basic-review, from ITS OWN lane: resolve the branch to a
-        commit, write it (and the changed files) into the review context file,
-        and record `gc.build.review_commit` on the workflow root (modelled as a
-        dict: the bead store is not part of this test)."""
-        commit_id = out(lane, "rev-parse", branch)
+    REVIEW_COMMIT_KEY = "gc.review_commit"
+
+    def setup_records(self, lane: pathlib.Path, anchors: list[str]) -> tuple[pathlib.Path, dict[str, dict[str, str]]]:
+        """setup-build-basic-review, from ITS OWN lane: one record PER SOURCE
+        ANCHOR in the review context file (the anchor id, its branch, the
+        branch's commit, the changed files), and `gc.review_commit` on EACH
+        source anchor (the anchors' metadata modelled as a dict per anchor id:
+        the bead store is not part of this test). Nothing is recorded on the
+        workflow root. The branch is named for the source anchor."""
         context = self.root / "artifacts" / "code-review-context.md"
         context.parent.mkdir(parents=True, exist_ok=True)
-        changed = out(lane, "diff-tree", "--no-commit-id", "--name-only", "-r", commit_id)
-        context.write_text(
-            f"branch: {branch}\ncommit: {commit_id}\nchanged_files: {changed}\n",
-            encoding="utf-8",
-        )
-        root_metadata = {"gc.build.review_commit": commit_id}
-        return context, root_metadata
+        records = []
+        anchor_metadata: dict[str, dict[str, str]] = {}
+        for anchor in anchors:
+            commit_id = out(lane, "rev-parse", anchor)
+            changed = out(lane, "diff-tree", "--no-commit-id", "--name-only", "-r", commit_id)
+            records.append(f"anchor: {anchor}\nbranch: {anchor}\ncommit: {commit_id}\nchanged_files: {changed}\n")
+            anchor_metadata[anchor] = {self.REVIEW_COMMIT_KEY: commit_id}
+        context.write_text("\n".join(records), encoding="utf-8")
+        return context, anchor_metadata
 
     @staticmethod
-    def context_commit(context: pathlib.Path) -> str:
-        for line in context.read_text(encoding="utf-8").splitlines():
-            if line.startswith("commit: "):
-                return line[len("commit: "):]
-        raise AssertionError("no commit in the review context")
+    def context_records(context: pathlib.Path) -> dict[str, dict[str, str]]:
+        """The context file's records, keyed by source anchor id."""
+        records: dict[str, dict[str, str]] = {}
+        for block in context.read_text(encoding="utf-8").split("\n\n"):
+            fields = dict(line.split(": ", 1) for line in block.splitlines() if ": " in line)
+            if "anchor" in fields:
+                records[fields["anchor"]] = fields
+        return records
 
     @staticmethod
-    def reader_reads_current_commit(context: pathlib.Path, root_metadata: dict[str, str]) -> str:
-        """A review lane: `gc.build.review_commit` on the workflow root first,
-        the context file's commit only when the key is absent."""
-        return root_metadata.get("gc.build.review_commit") or Rig.context_commit(context)
+    def context_commit(context: pathlib.Path, anchor: str) -> str:
+        record = Rig.context_records(context).get(anchor)
+        if record is None or "commit" not in record:
+            raise AssertionError(f"no record for {anchor} in the review context")
+        return record["commit"]
 
-    def fix_lane_refreshes(self, lane: pathlib.Path, context: pathlib.Path, root_metadata: dict[str, str]) -> str:
+    @staticmethod
+    def reader_reads_current_commit(
+        context: pathlib.Path, anchor_metadata: dict[str, dict[str, str]], anchor: str
+    ) -> str:
+        """A review lane, for ONE source anchor: `gc.review_commit` on that
+        anchor first, that anchor's record in the context file only when the
+        key is absent. No workflow-wide key exists to read."""
+        return anchor_metadata.get(anchor, {}).get(Rig.REVIEW_COMMIT_KEY) or Rig.context_commit(context, anchor)
+
+    def fix_lane_refreshes(
+        self, lane: pathlib.Path, context: pathlib.Path, anchor_metadata: dict[str, dict[str, str]], anchor: str
+    ) -> str:
         """apply-review-findings, after its fix commit and BEFORE the release:
-        rewrite the commit id and changed files in the context file, then record
-        the new commit on the workflow root."""
+        rewrite the commit id and changed files in the record of the source
+        anchor it committed on, then record the new commit on that anchor.
+        Every other anchor's record and key are left untouched."""
         new_commit = out(lane, "rev-parse", "HEAD")
-        old_commit = self.context_commit(context)
         changed = out(lane, "diff-tree", "--no-commit-id", "--name-only", "-r", new_commit)
-        text = context.read_text(encoding="utf-8").replace(f"commit: {old_commit}", f"commit: {new_commit}")
-        text = "\n".join(
-            f"changed_files: {changed}" if line.startswith("changed_files: ") else line
-            for line in text.splitlines()
-        ) + "\n"
-        context.write_text(text, encoding="utf-8")
-        root_metadata["gc.build.review_commit"] = new_commit
+        blocks = context.read_text(encoding="utf-8").split("\n\n")
+        for index, block in enumerate(blocks):
+            if f"anchor: {anchor}\n" not in block + "\n":
+                continue
+            lines = []
+            for line in block.splitlines():
+                if line.startswith("commit: "):
+                    line = f"commit: {new_commit}"
+                elif line.startswith("changed_files: "):
+                    line = f"changed_files: {changed}"
+                lines.append(line)
+            blocks[index] = "\n".join(lines) + ("\n" if block.endswith("\n") else "")
+        context.write_text("\n\n".join(blocks), encoding="utf-8")
+        anchor_metadata.setdefault(anchor, {})[self.REVIEW_COMMIT_KEY] = new_commit
         return new_commit
 
     @staticmethod
@@ -219,39 +254,49 @@ class Rig:
         )
 
 
-    # --- round 8: the Workspace fallback for a role with no lane -------------
+    # --- round 9: a role session outside a lane ------------------------------
 
     @staticmethod
-    def fallback_resolves_base(rig_root: pathlib.Path) -> tuple[str, str]:
-        """The role prompt's Workspace fallback, as the paragraph orders it
-        (the order worker-worktree.sh uses): the rig's remote, `origin` or its
-        other name, fetched, then `<remote>/HEAD`, `<remote>/main`,
-        `<remote>/master`; else the rig checkout's current HEAD. The base is
-        pinned to a commit in the rig. Returns (base, commit)."""
-        remotes = out(rig_root, "remote").split()
-        remote = "origin" if "origin" in remotes else (remotes[0] if remotes else None)
-        base = "HEAD"
-        if remote is not None:
-            git(rig_root, "fetch", "--quiet", remote, check=False)
-            head = git(rig_root, "symbolic-ref", "--quiet", "--short", f"refs/remotes/{remote}/HEAD", check=False)
-            if head.returncode == 0:
-                base = head.stdout.strip()
-            elif git(rig_root, "show-ref", "--verify", "--quiet", f"refs/remotes/{remote}/main", check=False).returncode == 0:
-                base = f"{remote}/main"
-            elif git(rig_root, "show-ref", "--verify", "--quiet", f"refs/remotes/{remote}/master", check=False).returncode == 0:
-                base = f"{remote}/master"
-        commit_id = out(rig_root, "rev-parse", "--verify", "--quiet", f"{base}^{{commit}}")
-        return base, commit_id
+    def repository_state(checkout: pathlib.Path) -> dict[str, object]:
+        """Everything a session could have moved: every file under the
+        checkout (its `.git` aside), the checkout's HEAD, every ref, and the
+        worktree list. Equal before and after means byte-identical."""
+        files = {
+            str(path.relative_to(checkout)): path.read_bytes()
+            for path in sorted(checkout.rglob("*"))
+            if path.is_file() and ".git" not in path.relative_to(checkout).parts
+        }
+        return {
+            "files": files,
+            "head": (checkout / ".git" / "HEAD").read_bytes(),
+            "refs": out(checkout, "for-each-ref"),
+            "worktrees": out(checkout, "worktree", "list", "--porcelain"),
+            "branch": out(checkout, "branch", "--show-current"),
+            "status": out(checkout, "status", "--porcelain"),
+        }
 
-    def fallback_creates_workspace(self, bead: str) -> pathlib.Path:
-        """The fallback's create step: `<city>/.worktrees/<rig>/<bead>` on a
-        new branch named for the bead, from the pinned commit, registered
-        from the rig root (reads refs there, never its working tree)."""
-        _base, commit_id = self.fallback_resolves_base(self.rig)
-        path = self.lanes_root / bead
-        path.parent.mkdir(parents=True, exist_ok=True)
-        git(self.rig, "worktree", "add", "--quiet", "-b", bead, str(path), commit_id)
-        return path
+    def session_without_lane(
+        self, gc_dir: pathlib.Path, commit_id: str, path: str, *, needs_checkout: bool
+    ) -> tuple[dict[str, str], str, str]:
+        """The role prompt's Workspace paragraph for a session outside a
+        gc-made lane: the boundary test fails, so no switch, no detach, no
+        branch, no commit and no worktree; the item is read by `git show` /
+        `git log -1` only, and a step that needs a checkout closes
+        `gc.outcome=fail`, `gc.failure_class=no-lane`, naming the fix."""
+        assert not all(self.boundary_test(gc_dir, self.rig)), "this is a lane"
+        content = out(gc_dir, "show", f"{commit_id}:{path}")
+        seen = out(gc_dir, "log", "-1", "--format=%H", commit_id)
+        if needs_checkout:
+            return (
+                {
+                    "gc.outcome": "fail",
+                    "gc.failure_class": "no-lane",
+                    "reason": "no lane for this role: the city must give it one ([[patches.agent]] work_dir + pre_start in city.toml)",
+                },
+                content,
+                seen,
+            )
+        return {"gc.outcome": "pass"}, content, seen
 
 
 class LaneLifecycleTests(unittest.TestCase):
@@ -406,10 +451,11 @@ class LaneLifecycleTests(unittest.TestCase):
 
     def test_fix_lane_refreshes_the_recorded_commit_so_the_next_attempt_reviews_the_fix(self) -> None:
         """Rule 6 (gate r6 M1). The setup records commit A once; the fix lane
-        commits B and refreshes the context file and the root key BEFORE it
-        releases; a reader on the next attempt reads B (from the key first,
-        from the context when the key is absent), detaches at B, and sees the
-        fix. A is gone from the context. The rig root never changes."""
+        commits B and refreshes the anchor's record in the context file and
+        the anchor's key BEFORE it releases; a reader on the next attempt
+        reads B (from the anchor's key first, from the anchor's record when
+        the key is absent), detaches at B, and sees the fix. A is gone from
+        the context. The rig root never changes."""
         rig = self.rig
         operator = rig.lane("run-operator")
         implement = rig.lane("implementation-worker-1")
@@ -424,13 +470,13 @@ class LaneLifecycleTests(unittest.TestCase):
         rig.writer_releases(implement)
 
         # setup-build-basic-review, ONCE, outside the loop: records A.
-        context, root_metadata = rig.setup_records(setup, ITEM_BRANCH)
-        self.assertEqual(rig.context_commit(context), commit_a)
-        self.assertEqual(root_metadata["gc.build.review_commit"], commit_a)
+        context, anchors = rig.setup_records(setup, [ITEM_BRANCH])
+        self.assertEqual(rig.context_commit(context, ITEM_BRANCH), commit_a)
+        self.assertEqual(anchors, {ITEM_BRANCH: {"gc.review_commit": commit_a}})
         self.assertIn("changed_files: feature.txt", context.read_text(encoding="utf-8"))
 
         # Attempt 1: a reader reads A, detaches at A, finds the defect.
-        current = rig.reader_reads_current_commit(context, root_metadata)
+        current = rig.reader_reads_current_commit(context, anchors, ITEM_BRANCH)
         self.assertEqual(current, commit_a)
         proc = rig.reader_detaches(reviewer_1, current)
         _, err = proc.communicate(timeout=60)
@@ -445,7 +491,7 @@ class LaneLifecycleTests(unittest.TestCase):
         git(fix, "-c", "user.name=t", "-c", "user.email=t@example.invalid", "commit", "--quiet", "--amend", "--no-edit")
         commit_b = out(fix, "rev-parse", "HEAD")
         self.assertNotEqual(commit_b, commit_a)
-        refreshed = rig.fix_lane_refreshes(fix, context, root_metadata)
+        refreshed = rig.fix_lane_refreshes(fix, context, anchors, ITEM_BRANCH)
         # The refresh happened while the fix lane still HOLDS the branch (before the release).
         self.assertEqual(rig.holder_of(ITEM_BRANCH), str(fix))
         self.assertEqual(refreshed, commit_b)
@@ -454,16 +500,17 @@ class LaneLifecycleTests(unittest.TestCase):
         # Never leave the old commit in the context after a fix.
         context_text = context.read_text(encoding="utf-8")
         self.assertNotIn(commit_a, context_text)
-        self.assertEqual(rig.context_commit(context), commit_b)
+        self.assertEqual(rig.context_commit(context, ITEM_BRANCH), commit_b)
         self.assertIn("changed_files: feature.txt feature_test.txt", " ".join(context_text.split()))
-        self.assertEqual(root_metadata["gc.build.review_commit"], commit_b)
+        self.assertEqual(anchors[ITEM_BRANCH]["gc.review_commit"], commit_b)
         self.assertEqual(out(operator, "log", "-1", "--format=%H", ITEM_BRANCH), commit_b)
 
-        # Attempt 2: a reader reads B, not A: from the key first ...
-        current = rig.reader_reads_current_commit(context, root_metadata)
+        # Attempt 2: a reader reads B, not A: from the anchor's key first ...
+        current = rig.reader_reads_current_commit(context, anchors, ITEM_BRANCH)
         self.assertEqual(current, commit_b)
-        # ... and from the context file when the key is absent.
-        self.assertEqual(rig.reader_reads_current_commit(context, {}), commit_b)
+        # ... and from the anchor's record in the context file when the key is absent.
+        self.assertEqual(rig.reader_reads_current_commit(context, {}, ITEM_BRANCH), commit_b)
+        self.assertEqual(rig.reader_reads_current_commit(context, {ITEM_BRANCH: {}}, ITEM_BRANCH), commit_b)
         proc = rig.reader_detaches(reviewer_2, current)
         _, err = proc.communicate(timeout=60)
         self.assertEqual(proc.returncode, 0, err)
@@ -544,52 +591,134 @@ class LaneLifecycleTests(unittest.TestCase):
         self.assertNotEqual(rig.snapshot(rig_root_as_gc_dir), rig.rig_before)
 
 
+    def test_role_session_without_a_lane_reads_detached_creates_no_worktree_and_moves_nothing(self) -> None:
+        """Rule 8 (round 9; Afik: drop the fallback). A role the city gave no
+        `work_dir` starts in the rig root: `$GC_DIR` is the human checkout and
+        the boundary test fails. The session reads the item by `git show` /
+        `git log -1` only, creates no worktree, creates and moves no branch,
+        and a step that needs a checkout closes `gc.outcome=fail`,
+        `gc.failure_class=no-lane` naming the fix. The rig checkout is
+        byte-identical after: every file under it, its HEAD, every ref, the
+        worktree list. Rounds 2 to 8 had this session make and enter
+        `<city>/.worktrees/<rig>/<bead>` from here; that path is gone."""
+        rig = self.rig
+        operator = rig.lane("run-operator")
+        implement = rig.lane("implementation-worker-1")
+        rig.operator_prepares(operator)
+        rig.writer_takes(implement)
+        recorded = commit(implement, "feature.txt", "implemented\n", "implement")
+        rig.writer_releases(implement)
+
+        gc_dir = rig.rig  # a role with no lane: $GC_DIR is the rig root
+        self.assertEqual(Rig.boundary_test(gc_dir, rig.rig), (True, False, True))
+        before = rig.repository_state(gc_dir)
+        self.assertEqual(before["worktrees"].count("worktree "), 3)  # the rig, the operator, the implementer
+
+        # A read-only step: reads the item, closes pass.
+        outcome, content, seen = rig.session_without_lane(gc_dir, recorded, "feature.txt", needs_checkout=False)
+        self.assertEqual(outcome, {"gc.outcome": "pass"})
+        self.assertEqual((content, seen), ("implemented", recorded))
+        # A step that needs a checkout at the commit: fails closed, no-lane, names the fix.
+        outcome, content, seen = rig.session_without_lane(gc_dir, recorded, "feature.txt", needs_checkout=True)
+        self.assertEqual((outcome["gc.outcome"], outcome["gc.failure_class"]), ("fail", "no-lane"))
+        self.assertIn("[[patches.agent]]", outcome["reason"])
+        self.assertEqual((content, seen), ("implemented", recorded))
+
+        # Nothing moved: no worktree, no branch, no detach, no file; byte-identical.
+        after = rig.repository_state(gc_dir)
+        self.assertEqual(after, before)
+        self.assertEqual(after["worktrees"].count("worktree "), 3)
+        self.assertEqual(out(gc_dir, "branch", "--show-current"), "main")
+        self.assertEqual(out(gc_dir, "rev-parse", "HEAD"), rig.main_sha)
+        self.assertFalse((gc_dir / "feature.txt").exists())  # the commit was read, never checked out
+        self.assertEqual(sorted(path.name for path in rig.lanes_root.iterdir()), ["lane-gc.implementation-worker-1", "lane-gc.run-operator"])
+        self.assertIsNone(rig.holder_of(ITEM_BRANCH))
+        self.assert_no_contention()
+        self.assert_rig_root_untouched()
+
+    def test_two_source_anchors_keep_their_own_review_commits_when_one_is_fixed(self) -> None:
+        """Rule 9 (gate r8 MAJOR). Two drains produce two source anchors on
+        independent branches. The setup records each item's commit on ITS
+        anchor; a fix on item 1 refreshes item 1's record and key only; item
+        2's recorded commit is unchanged, and item 2's reader detaches at
+        item 2's own revision, where item 1's files do not exist. One
+        workflow-wide key (round 7's shape), overwritten by the fix, would
+        have sent item 2's reader to item 1's fix commit."""
+        rig = self.rig
+        item_1, item_2 = "gp-item1", "gp-item2"
+        operator = rig.lane("run-operator")
+        impl_1 = rig.lane("implementation-worker-1")
+        impl_2 = rig.lane("implementation-worker-2")
+        setup = rig.lane("run-operator-2")
+        reviewer_1 = rig.lane("implementation-reviewer-1")
+        reviewer_2 = rig.lane("implementation-reviewer-2")
+        fix = rig.lane("implementation-worker-3")
+
+        # Two drains: two branches from main, two implementers, both released.
+        rig.operator_prepares(operator, item_1)
+        rig.operator_prepares(operator, item_2)
+        rig.writer_takes(impl_1, item_1)
+        a1 = commit(impl_1, "one.txt", "one\n", "implement item 1")
+        rig.writer_releases(impl_1)
+        rig.writer_takes(impl_2, item_2)
+        a2 = commit(impl_2, "two.txt", "two\n", "implement item 2")
+        rig.writer_releases(impl_2)
+        self.assertNotEqual(a1, a2)
+        # Independent branches: neither commit is an ancestor of the other.
+        self.assertNotEqual(git(rig.rig, "merge-base", "--is-ancestor", a1, a2, check=False).returncode, 0)
+        self.assertNotEqual(git(rig.rig, "merge-base", "--is-ancestor", a2, a1, check=False).returncode, 0)
+
+        # setup-build-basic-review, ONCE: one record and one key per anchor.
+        context, anchors = rig.setup_records(setup, [item_1, item_2])
+        self.assertEqual(anchors, {item_1: {"gc.review_commit": a1}, item_2: {"gc.review_commit": a2}})
+        self.assertEqual(rig.context_commit(context, item_1), a1)
+        self.assertEqual(rig.context_commit(context, item_2), a2)
+        self.assertEqual(rig.context_records(context)[item_2]["changed_files"], "two.txt")
+
+        # apply-review-findings fixes item 1 ONLY: take, commit, refresh item 1's record, release.
+        rig.writer_takes(fix, item_1)
+        b1 = commit(fix, "one.txt", "one\nfixed\n", "fix item 1")
+        self.assertEqual(rig.fix_lane_refreshes(fix, context, anchors, item_1), b1)
+        rig.writer_releases(fix)
+
+        # Item 1 moved to B1; item 2's record and key are exactly as the setup left them.
+        self.assertEqual(anchors, {item_1: {"gc.review_commit": b1}, item_2: {"gc.review_commit": a2}})
+        self.assertEqual(rig.context_commit(context, item_1), b1)
+        self.assertEqual(rig.context_commit(context, item_2), a2)
+        context_text = context.read_text(encoding="utf-8")
+        self.assertNotIn(a1, context_text)
+        self.assertIn(a2, context_text)
+        self.assertEqual(rig.context_records(context)[item_2]["changed_files"], "two.txt")
+        self.assertEqual(out(operator, "log", "-1", "--format=%H", item_1), b1)
+        self.assertEqual(out(operator, "log", "-1", "--format=%H", item_2), a2)
+
+        # Attempt 2: each reader reads ITS anchor's commit and inspects that revision.
+        current_1 = rig.reader_reads_current_commit(context, anchors, item_1)
+        current_2 = rig.reader_reads_current_commit(context, anchors, item_2)
+        self.assertEqual((current_1, current_2), (b1, a2))
+        for reviewer, current in ((reviewer_1, current_1), (reviewer_2, current_2)):
+            proc = rig.reader_detaches(reviewer, current)
+            _, err = proc.communicate(timeout=60)
+            rig.stderr_seen.append(err)
+            self.assertEqual(proc.returncode, 0, err)
+        self.assertEqual(out(reviewer_1, "rev-parse", "HEAD"), b1)
+        self.assertEqual((reviewer_1 / "one.txt").read_text(encoding="utf-8"), "one\nfixed\n")
+        self.assertFalse((reviewer_1 / "two.txt").exists())
+        self.assertEqual(out(reviewer_2, "rev-parse", "HEAD"), a2)
+        self.assertEqual((reviewer_2 / "two.txt").read_text(encoding="utf-8"), "two\n")
+        self.assertFalse((reviewer_2 / "one.txt").exists())
+        # The round-7 shape, one key for the workflow overwritten by the fix,
+        # would have sent item 2's reader to B1, where item 2's file does not exist.
+        self.assertNotEqual(git(rig.rig, "cat-file", "-e", f"{b1}:two.txt", check=False).returncode, 0)
+        # The key-absent fallback is per anchor too: item 2's own record, not item 1's.
+        self.assertEqual(rig.reader_reads_current_commit(context, {}, item_2), a2)
+        self.assertEqual(rig.reader_reads_current_commit(context, {}, item_1), b1)
+
+        self.assertIsNone(rig.holder_of(item_1))
+        self.assertIsNone(rig.holder_of(item_2))
+        self.assert_no_contention()
+        self.assert_rig_root_untouched()
+
+
 if __name__ == "__main__":
     unittest.main()
-
-    def test_role_without_a_lane_in_a_rig_without_a_remote_gets_a_workspace_from_the_rig_head(self) -> None:
-        """Round 8 (gate r7): a role the city gave no work_dir starts in the rig
-        root and takes the Workspace fallback. This rig has NO remote, so the
-        round-7 text's `origin/<default branch>` does not exist; the resolution
-        the paragraph now documents ends at the rig checkout's HEAD, the
-        worker creates `<city>/.worktrees/<rig>/<bead>` from that commit,
-        works there, and the rig checkout's branch, HEAD and status never
-        move. A remote not named origin is then found by the same order."""
-        rig = self.rig
-        self.assertEqual(out(rig.rig, "remote"), "")
-        for ref in ("origin/HEAD", "origin/main", "origin/master"):
-            with self.subTest(missing=ref):
-                self.assertNotEqual(git(rig.rig, "rev-parse", "--verify", "--quiet", ref, check=False).returncode, 0)
-        # $GC_DIR is the rig root: the boundary test fails (part 2), so this is
-        # the fallback, not the lane case, and nothing is switched there.
-        self.assertEqual(Rig.boundary_test(rig.rig, rig.rig), (True, False, True))
-
-        base, commit_id = Rig.fallback_resolves_base(rig.rig)
-        self.assertEqual((base, commit_id), ("HEAD", rig.main_sha))
-
-        bead = "gp-nolane1"
-        self.assertNotEqual(git(rig.rig, "rev-parse", "--verify", "--quiet", f"refs/heads/{bead}", check=False).returncode, 0)
-        workspace = rig.fallback_creates_workspace(bead)
-        self.assertEqual(workspace, rig.lanes_root / bead)
-        self.assertEqual(out(workspace, "branch", "--show-current"), bead)
-        self.assertEqual(out(workspace, "rev-parse", "HEAD"), rig.main_sha)
-        self.assertEqual(Rig.boundary_test(workspace, rig.rig), (True, True, True))
-        # The worker works there: a commit lands on the bead's branch, not on main.
-        done = commit(workspace, "work.txt", "done\n", "work in the fallback workspace")
-        self.assertEqual(out(rig.rig, "rev-parse", bead), done)
-        self.assertEqual(out(rig.rig, "rev-parse", "main"), rig.main_sha)
-        self.assert_rig_root_untouched()
-        self.assert_no_contention()
-
-        # The same order finds a remote that is not named origin: its default
-        # branch wins over the rig's HEAD, so the paragraph's first candidate
-        # is real, not only its last.
-        mirror = rig.root / "mirror.git"
-        subprocess.run(["git", "clone", "--quiet", "--bare", str(rig.rig), str(mirror)], check=True)
-        git(rig.rig, "remote", "add", "upstream", str(mirror))
-        git(rig.rig, "fetch", "--quiet", "upstream")
-        git(rig.rig, "remote", "set-head", "upstream", "--auto")
-        self.assertEqual(out(rig.rig, "remote"), "upstream")
-        base, commit_id = Rig.fallback_resolves_base(rig.rig)
-        self.assertEqual((base, commit_id), ("upstream/main", rig.main_sha))
-        self.assert_rig_root_untouched()

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import os
 import pathlib
 import subprocess
-import unittest
 import tempfile
+import time
+import unittest
 
 
 SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "assets" / "scripts" / "worker-worktree.sh"
@@ -70,12 +71,14 @@ class Fixture:
         git(scratch, "push", "--quiet", "origin", name)
         return sha
 
-    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True, mkdir: bool = True) -> subprocess.CompletedProcess[str]:
+    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True, mkdir: bool = True, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
         env = {
             **os.environ,
             "GC_DIR": str(workdir),
             "GC_RIG_ROOT": str(self.rig),
             "GC_CITY": str(self.city),
+            "WORKER_WORKTREE_LOCK_WAIT": "10",
+            **(env_extra or {}),
         }
         env.pop("GC_TRIGGER_BEAD_ID", None)
         if bead is not None:
@@ -128,7 +131,8 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertTrue((self.lane / "README.md").is_file())
         self.assertEqual(proc.stdout.split(), ["WORKTREE", str(self.lane), "gp-abc1", self.fx.main_sha[:7]])
 
-    def test_workdir_that_does_not_exist_yet_is_created(self) -> None:
+    def test_workdir_that_does_not_exist_yet_is_created_when_its_parent_does(self) -> None:
+        self.lane.parent.mkdir(parents=True)
         proc = self.fx.run(self.lane, "gp-abc1", mkdir=False)
         self.assert_is_worktree(self.lane)
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
@@ -323,6 +327,73 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(self.branch_of(self.lane), "HEAD")
         self.assertNotIn("WARN", proc.stderr)
 
+    # --- foreign checkouts and the lock -----------------------------------------------------------
+
+    def test_checkout_of_another_repository_at_the_lane_is_refused_not_moved(self) -> None:
+        self.lane.mkdir(parents=True)
+        subprocess.run(["git", "init", "--quiet", str(self.lane)], check=True)
+        (self.lane / "theirs.txt").write_text("someone else's repo\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("another repository", proc.stderr)
+        self.assertEqual(self.asides(), [])
+        self.assertEqual((self.lane / "theirs.txt").read_text(encoding="utf-8"), "someone else's repo\n")
+
+    def lock_dir(self) -> pathlib.Path:
+        return self.fx.rig / ".git" / "worker-worktree.lock"
+
+    def test_lock_is_taken_and_released(self) -> None:
+        self.fx.run(self.lane, "gp-abc1")
+        self.assertFalse(self.lock_dir().exists())
+
+    def test_stale_lock_from_a_dead_pid_is_cleared(self) -> None:
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertIn("clearing stale lock", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertFalse(self.lock_dir().exists())
+
+    def orphan_sleep(self, seconds: int) -> int:
+        """Start `sleep` reparented to init so the OS reaps it when it exits."""
+        out = subprocess.run(["sh", "-c", f"sleep {seconds} >/dev/null 2>&1 & echo $!"], check=True, capture_output=True, text=True).stdout
+        return int(out.strip())
+
+    def test_live_lock_is_waited_for(self) -> None:
+        pid = self.orphan_sleep(3)
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text(f"{pid}\n", encoding="utf-8")
+        started = time.monotonic()
+        proc = self.fx.run(self.lane, "gp-abc1")
+        elapsed = time.monotonic() - started
+        self.assertGreaterEqual(elapsed, 2.0)
+        self.assertIn("waiting for another run", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertFalse(self.lock_dir().exists())
+
+    def test_live_lock_held_too_long_fails_closed(self) -> None:
+        pid = self.orphan_sleep(8)
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text(f"{pid}\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-abc1", check=False, env_extra={"WORKER_WORKTREE_LOCK_WAIT": "2"})
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("has held", proc.stderr)
+        self.assertFalse((self.lane / ".git").exists())
+        self.assertTrue(self.lock_dir().exists())  # not ours to clear while its owner lives
+        os.kill(pid, 15)
+
+    def test_zombie_lock_owner_counts_as_dead(self) -> None:
+        holder = subprocess.Popen(["sleep", "0"])  # exits at once; not reaped until wait()
+        time.sleep(0.5)
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text(f"{holder.pid}\n", encoding="utf-8")
+        try:
+            proc = self.fx.run(self.lane, "gp-abc1")
+        finally:
+            holder.wait()
+        self.assertIn("clearing stale lock", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+
     # --- refusals ----------------------------------------------------------------------------
 
     def test_workdir_inside_rig_root_is_refused_even_if_it_does_not_exist(self) -> None:
@@ -334,6 +405,27 @@ class WorkerWorktreeTests(unittest.TestCase):
         proc = self.fx.run(self.fx.rig, "gp-abc1", check=False)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("is the rig root", proc.stderr)
+
+    def test_workdir_whose_parent_does_not_exist_is_refused(self) -> None:
+        deep = self.fx.city / "missing" / "deeper" / "lane"
+        proc = self.fx.run(deep, "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("parent of work dir does not exist", proc.stderr)
+        self.assertFalse((self.fx.city / "missing").exists())
+
+    def test_dot_dot_cannot_reach_into_the_rig_root(self) -> None:
+        via_existing = self.fx.rig / ".." / "rig" / "nested"
+        proc = self.fx.run(via_existing, "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("inside the rig root", proc.stderr)
+        self.assertFalse((self.fx.rig / "nested").exists())
+        via_missing = self.fx.root / "nope" / ".." / "rig" / "nested"
+        proc = self.fx.run(via_missing, "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertFalse((self.fx.rig / "nested").exists())
+        trailing_dots = self.fx.city / "lane" / ".."
+        proc = self.fx.run(trailing_dots, "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
 
     def test_workdir_that_is_an_ancestor_of_the_rig_root_is_refused(self) -> None:
         proc = self.fx.run(self.fx.root, "gp-abc1", check=False)

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -453,7 +453,9 @@ class WorkerWorktreeTests(unittest.TestCase):
             cwd=str(lane_b), env={**base_env, "GC_DIR": str(lane_b), "WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM": "3"},
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
         )
-        time.sleep(0.7)
+        # Start A only once B has observed the stale lock and entered its pause.
+        marker = b.stderr.readline()
+        self.assertIn("TEST pausing before reclaim", marker)
         a_started = time.monotonic()
         a = subprocess.run(
             ["sh", str(SCRIPT), "--no-fetch", "--bead", "gp-aaa1"],

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -437,8 +437,9 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(sorted(self.fx.rig.joinpath(".git").glob("worker-worktree.lock*")), [])
 
     def test_two_contenders_reclaiming_one_stale_lock_do_not_run_concurrently(self) -> None:
-        """B sees the stale lock and pauses inside its reclaim; A reclaims, acquires
-        and holds; B must find A's live lock under re-check and wait, not clear it."""
+        """B observes the stale lock and pauses before taking the reclaim lock; A
+        observes it, reclaims, acquires and holds. B must then find A's live lock
+        under its own re-check, leave it alone, and wait for A to release."""
         self.lock_dir().mkdir()
         (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
         lane_a = self.fx.city / "lane-a"
@@ -459,36 +460,35 @@ class WorkerWorktreeTests(unittest.TestCase):
             cwd=str(lane_a), env={**base_env, "GC_DIR": str(lane_a), "WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE": "4"},
             capture_output=True, text=True,
         )
-        a_finished = time.monotonic()
+        a_elapsed = time.monotonic() - a_started
         b_out, b_err = b.communicate(timeout=60)
-        b_finished = time.monotonic()
         self.assertEqual(a.returncode, 0, a.stderr)
         self.assertEqual(b.returncode, 0, b_err)
-        # Exactly one contender cleared the stale lock, both prepared their lanes,
-        # and B (paused inside its reclaim while A acquired and held) finished
-        # only after A released: it found A's live lock under re-check and waited.
-        cleared = (a.stderr + b_err).count("clearing stale lock")
-        self.assertEqual(cleared, 1, a.stderr + b_err)
-        self.assertGreaterEqual(b_finished, a_finished)
+        # A cleared the stale lock (B was paused before its reclaim); B never did.
+        self.assertIn("clearing stale lock", a.stderr)
+        self.assertNotIn("clearing stale lock", b_err)
+        # B saw A's live lock under re-check and waited for it instead of removing it.
+        self.assertIn("waiting for another run", b_err)
+        self.assertGreater(a_elapsed, 3.5)  # A really held the lock across B's resume
         self.assertEqual(self.branch_of(lane_a), "gp-aaa1")
         self.assertEqual(self.branch_of(lane_b), "gp-bbb1")
         self.assertFalse(self.lock_dir().exists())
         self.assertFalse((self.fx.rig / ".git" / "worker-worktree.lock.reclaim").exists())
-        self.assertGreater(a_finished - a_started, 3.5)  # A really held the lock
 
-    def test_stuck_reclaim_lock_bounds_the_wait_and_ages_out(self) -> None:
+    def test_stuck_reclaim_lock_bounds_the_wait_then_fails_closed_when_old(self) -> None:
         self.lock_dir().mkdir()
         (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
         reclaim = self.fx.rig / ".git" / "worker-worktree.lock.reclaim"
         reclaim.mkdir()
         proc = self.fx.run(self.lane, "gp-abc1", check=False, env_extra={"WORKER_WORKTREE_LOCK_WAIT": "2"})
-        self.assertNotEqual(proc.returncode, 0)  # bounded, not an infinite loop
+        self.assertNotEqual(proc.returncode, 0)  # fresh reclaim lock: bounded wait, not an infinite loop
         self.assertIn("has held", proc.stderr)
         os.utime(reclaim, (time.time() - 300, time.time() - 300))
-        proc = self.fx.run(self.lane, "gp-abc1")
-        self.assertIn("clearing stale lock", proc.stderr)
-        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
-        self.assertFalse(reclaim.exists())
+        proc = self.fx.run(self.lane, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)  # old reclaim lock: fail closed, never auto-removed
+        self.assertIn("stale reclaim lock", proc.stderr)
+        self.assertTrue(reclaim.exists())
+        self.assertFalse((self.lane / ".git").exists())
 
     def test_remote_name_with_metacharacters_still_matches_remote_bead_branches(self) -> None:
         git(self.fx.rig, "remote", "rename", "origin", "team|origin")

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -1,0 +1,240 @@
+"""Contract tests for gascity/assets/scripts/worker-worktree.sh.
+
+Each test builds a throwaway "remote" (bare repo) plus a rig checkout, then
+runs the script the way gc runs a pre_start command: cwd = the work dir,
+GC_DIR / GC_RIG_ROOT / GC_TRIGGER_BEAD_ID in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import unittest
+import tempfile
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "assets" / "scripts" / "worker-worktree.sh"
+
+
+def git(cwd: pathlib.Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def commit(repo: pathlib.Path, name: str, content: str, message: str) -> str:
+    (repo / name).write_text(content, encoding="utf-8")
+    git(repo, "add", name)
+    git(
+        repo,
+        "-c", "user.name=t", "-c", "user.email=t@example.invalid",
+        "commit", "--quiet", "-m", message,
+    )
+    return git(repo, "rev-parse", "HEAD")
+
+
+class Fixture:
+    def __init__(self, root: pathlib.Path) -> None:
+        self.root = root
+        self.remote = root / "remote.git"
+        self.rig = root / "rig"
+        self.city = root / "city"
+        subprocess.run(["git", "init", "--quiet", "--bare", "-b", "main", str(self.remote)], check=True)
+        subprocess.run(["git", "init", "--quiet", "-b", "main", str(self.rig)], check=True)
+        git(self.rig, "remote", "add", "origin", str(self.remote))
+        self.main_sha = commit(self.rig, "README.md", "hello\n", "init")
+        git(self.rig, "push", "--quiet", "-u", "origin", "main")
+        git(self.rig, "remote", "set-head", "origin", "main")
+        self.rig_status_before = self.rig_snapshot()
+
+    def rig_snapshot(self) -> tuple[str, str, str]:
+        return (
+            git(self.rig, "rev-parse", "--abbrev-ref", "HEAD"),
+            git(self.rig, "rev-parse", "HEAD"),
+            git(self.rig, "status", "--porcelain"),
+        )
+
+    def push_branch(self, name: str, filename: str = "feature.txt") -> str:
+        """Create a branch on the remote (not present locally in the rig)."""
+        scratch = self.root / f"scratch-{name.replace('/', '_')}"
+        subprocess.run(["git", "clone", "--quiet", str(self.remote), str(scratch)], check=True)
+        git(scratch, "switch", "--quiet", "-c", name)
+        sha = commit(scratch, filename, f"{name}\n", f"work on {name}")
+        git(scratch, "push", "--quiet", "origin", name)
+        return sha
+
+    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        env = {
+            **os.environ,
+            "GC_DIR": str(workdir),
+            "GC_RIG_ROOT": str(self.rig),
+            "GC_CITY": str(self.city),
+        }
+        env.pop("GC_TRIGGER_BEAD_ID", None)
+        if bead is not None:
+            env["GC_TRIGGER_BEAD_ID"] = bead
+        workdir.mkdir(parents=True, exist_ok=True)  # gc MkdirAll's work_dir before pre_start
+        proc = subprocess.run(
+            ["sh", str(SCRIPT), *extra],
+            cwd=str(workdir),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if check:
+            assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        return proc
+
+
+class WorkerWorktreeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.fx = Fixture(pathlib.Path(self._tmp.name).resolve())
+        self.lane = self.fx.city / ".worktrees" / "rig" / "lane-worker"
+
+    def tearDown(self) -> None:
+        # The rig root's working tree is never touched, whatever the case.
+        self.assertEqual(self.fx.rig_snapshot(), self.fx.rig_status_before)
+        self._tmp.cleanup()
+
+    def branch_of(self, path: pathlib.Path) -> str:
+        return git(path, "rev-parse", "--abbrev-ref", "HEAD")
+
+    def assert_is_worktree(self, path: pathlib.Path) -> None:
+        common = pathlib.Path(git(path, "rev-parse", "--git-common-dir"))
+        if not common.is_absolute():
+            common = path / common
+        self.assertEqual(common.resolve(), (self.fx.rig / ".git").resolve())
+
+    def test_empty_workdir_new_bead_creates_branch_from_base(self) -> None:
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assert_is_worktree(self.lane)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        self.assertTrue((self.lane / "README.md").is_file())
+        self.assertEqual(proc.stdout.split(), ["WORKTREE", str(self.lane), "gp-abc1", self.fx.main_sha[:7]])
+
+    def test_rerun_is_idempotent(self) -> None:
+        self.fx.run(self.lane, "gp-abc1")
+        first = git(self.lane, "rev-parse", "HEAD")
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), first)
+        self.assertNotIn("WARN", proc.stderr)
+
+    def test_existing_remote_branch_named_for_bead_is_checked_out_and_tracked(self) -> None:
+        sha = self.fx.push_branch("fix/gp-def2-resume-me")
+        self.fx.run(self.lane, "gp-def2")
+        self.assertEqual(self.branch_of(self.lane), "fix/gp-def2-resume-me")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
+        self.assertEqual(git(self.lane, "rev-parse", "--abbrev-ref", "@{upstream}"), "origin/fix/gp-def2-resume-me")
+        self.assertTrue((self.lane / "feature.txt").is_file())
+
+    def test_bead_branch_checked_out_elsewhere_is_not_stolen(self) -> None:
+        other = self.fx.root / "other-worktree"
+        git(self.fx.rig, "worktree", "add", "--quiet", "-b", "gp-ghi3-elsewhere", str(other), "origin/main")
+        sha = commit(other, "elsewhere.txt", "x\n", "elsewhere work")
+        proc = self.fx.run(self.lane, "gp-ghi3")
+        self.assertEqual(self.branch_of(self.lane), "HEAD")  # detached
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
+        self.assertIn("WARN", proc.stderr)
+        self.assertIn(str(other), proc.stderr)
+        self.assertEqual(self.branch_of(other), "gp-ghi3-elsewhere")
+        self.assertEqual(proc.stdout.split()[2], "detached")
+
+    def test_clean_lane_on_old_bead_switches_to_new_bead(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        commit(self.lane, "old.txt", "old\n", "old bead work")
+        # Untracked files (staged skills, hooks, node_modules) never count as dirt.
+        (self.lane / ".agents").mkdir()
+        (self.lane / ".agents" / "skills.txt").write_text("x", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-new2")
+        self.assertEqual(self.branch_of(self.lane), "gp-new2")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        self.assertFalse((self.lane / "old.txt").exists())
+        self.assertTrue((self.lane / ".agents" / "skills.txt").is_file())
+        self.assertNotIn("aside", proc.stderr)
+        # The old bead's branch and commit survive.
+        self.assertTrue(git(self.fx.rig, "rev-parse", "--verify", "gp-old1"))
+
+    def test_dirty_lane_is_moved_aside_never_reset(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        (self.lane / "README.md").write_text("uncommitted edit\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-new2")
+        self.assertIn("moved aside", proc.stderr)
+        asides = sorted(self.lane.parent.glob("lane-worker.aside-*"))
+        self.assertEqual(len(asides), 1)
+        self.assertEqual((asides[0] / "README.md").read_text(encoding="utf-8"), "uncommitted edit\n")
+        self.assertEqual(self.branch_of(asides[0]), "gp-old1")
+        self.assertEqual(self.branch_of(self.lane), "gp-new2")
+        self.assertEqual((self.lane / "README.md").read_text(encoding="utf-8"), "hello\n")
+        # git still knows both worktrees.
+        listing = git(self.fx.rig, "worktree", "list", "--porcelain")
+        self.assertIn(str(asides[0]), listing)
+        self.assertIn(str(self.lane), listing)
+
+    def test_nonempty_non_worktree_dir_is_moved_aside(self) -> None:
+        self.lane.mkdir(parents=True)
+        (self.lane / "junk.txt").write_text("keep me\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertIn("moved aside", proc.stderr)
+        asides = sorted(self.lane.parent.glob("lane-worker.aside-*"))
+        self.assertEqual(len(asides), 1)
+        self.assertEqual((asides[0] / "junk.txt").read_text(encoding="utf-8"), "keep me\n")
+        self.assert_is_worktree(self.lane)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+
+    def test_ambiguous_bead_branches_fail_closed(self) -> None:
+        self.fx.push_branch("gp-amb1-first", "a.txt")
+        self.fx.push_branch("gp-amb1-second", "b.txt")
+        proc = self.fx.run(self.lane, "gp-amb1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("several branches", proc.stderr)
+        self.assertIn("gp-amb1-first", proc.stderr)
+        self.assertIn("gp-amb1-second", proc.stderr)
+        self.assertFalse((self.lane / ".git").exists())
+
+    def test_no_bead_leaves_a_detached_worktree_at_base(self) -> None:
+        proc = self.fx.run(self.lane, None)
+        self.assert_is_worktree(self.lane)
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        self.assertEqual(proc.stdout.split()[2], "detached")
+
+    def test_no_bead_does_not_move_a_lane_off_its_branch(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        self.fx.run(self.lane, None)
+        self.assertEqual(self.branch_of(self.lane), "gp-old1")
+
+    def test_new_branch_tracks_fresh_remote_tip_not_stale_local_main(self) -> None:
+        # The rig checkout lags: origin/main moves on, local main does not.
+        newer = self.fx.push_branch("main-advance", "newer.txt")
+        scratch = self.fx.root / "scratch-main-advance"
+        git(scratch, "push", "--quiet", "origin", "main-advance:main")
+        self.fx.run(self.lane, "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), newer)
+        self.assertEqual(git(self.fx.rig, "rev-parse", "main"), self.fx.main_sha)
+
+    def test_workdir_inside_rig_root_is_refused(self) -> None:
+        inside = self.fx.rig / "nested"
+        proc = self.fx.run(inside, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("inside the rig root", proc.stderr)
+        proc = self.fx.run(self.fx.rig, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("is the rig root", proc.stderr)
+
+    def test_flags_override_environment(self) -> None:
+        lane = self.fx.city / "elsewhere"
+        proc = self.fx.run(self.lane, "gp-env1", "--workdir", str(lane), "--bead", "gp-flag2", "--no-fetch")
+        self.assertEqual(self.branch_of(lane), "gp-flag2")
+        self.assertFalse((self.lane / ".git").exists())
+        self.assertEqual(proc.stdout.split()[1], str(lane))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -71,6 +71,11 @@ class Fixture:
         git(scratch, "push", "--quiet", "origin", name)
         return sha
 
+    def push_branch_on(self, remote: str, name: str, filename: str) -> str:
+        sha = self.push_branch(name, filename)
+        git(self.rig, "fetch", "--quiet", remote)
+        return sha
+
     def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True, mkdir: bool = True, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
         env = {
             **os.environ,
@@ -430,6 +435,68 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
         self.assertFalse(self.lock_dir().exists())
         self.assertEqual(sorted(self.fx.rig.joinpath(".git").glob("worker-worktree.lock*")), [])
+
+    def test_two_contenders_reclaiming_one_stale_lock_do_not_run_concurrently(self) -> None:
+        """B sees the stale lock and pauses inside its reclaim; A reclaims, acquires
+        and holds; B must find A's live lock under re-check and wait, not clear it."""
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
+        lane_a = self.fx.city / "lane-a"
+        lane_b = self.fx.city / "lane-b"
+        for lane in (lane_a, lane_b):
+            lane.mkdir(parents=True)
+        base_env = {**os.environ, "GC_RIG_ROOT": str(self.fx.rig), "WORKER_WORKTREE_LOCK_WAIT": "20"}
+        base_env.pop("GC_TRIGGER_BEAD_ID", None)
+        b = subprocess.Popen(
+            ["sh", str(SCRIPT), "--no-fetch", "--bead", "gp-bbb1"],
+            cwd=str(lane_b), env={**base_env, "GC_DIR": str(lane_b), "WORKER_WORKTREE_TEST_PAUSE_BEFORE_RECLAIM": "3"},
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        time.sleep(0.7)
+        a_started = time.monotonic()
+        a = subprocess.run(
+            ["sh", str(SCRIPT), "--no-fetch", "--bead", "gp-aaa1"],
+            cwd=str(lane_a), env={**base_env, "GC_DIR": str(lane_a), "WORKER_WORKTREE_TEST_PAUSE_AFTER_ACQUIRE": "4"},
+            capture_output=True, text=True,
+        )
+        a_finished = time.monotonic()
+        b_out, b_err = b.communicate(timeout=60)
+        b_finished = time.monotonic()
+        self.assertEqual(a.returncode, 0, a.stderr)
+        self.assertEqual(b.returncode, 0, b_err)
+        # Exactly one contender cleared the stale lock, both prepared their lanes,
+        # and B (paused inside its reclaim while A acquired and held) finished
+        # only after A released: it found A's live lock under re-check and waited.
+        cleared = (a.stderr + b_err).count("clearing stale lock")
+        self.assertEqual(cleared, 1, a.stderr + b_err)
+        self.assertGreaterEqual(b_finished, a_finished)
+        self.assertEqual(self.branch_of(lane_a), "gp-aaa1")
+        self.assertEqual(self.branch_of(lane_b), "gp-bbb1")
+        self.assertFalse(self.lock_dir().exists())
+        self.assertFalse((self.fx.rig / ".git" / "worker-worktree.lock.reclaim").exists())
+        self.assertGreater(a_finished - a_started, 3.5)  # A really held the lock
+
+    def test_stuck_reclaim_lock_bounds_the_wait_and_ages_out(self) -> None:
+        self.lock_dir().mkdir()
+        (self.lock_dir() / "pid").write_text("999999\n", encoding="utf-8")
+        reclaim = self.fx.rig / ".git" / "worker-worktree.lock.reclaim"
+        reclaim.mkdir()
+        proc = self.fx.run(self.lane, "gp-abc1", check=False, env_extra={"WORKER_WORKTREE_LOCK_WAIT": "2"})
+        self.assertNotEqual(proc.returncode, 0)  # bounded, not an infinite loop
+        self.assertIn("has held", proc.stderr)
+        os.utime(reclaim, (time.time() - 300, time.time() - 300))
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertIn("clearing stale lock", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertFalse(reclaim.exists())
+
+    def test_remote_name_with_metacharacters_still_matches_remote_bead_branches(self) -> None:
+        git(self.fx.rig, "remote", "rename", "origin", "team|origin")
+        git(self.fx.rig, "remote", "set-head", "team|origin", "main")
+        sha = self.fx.push_branch_on("team|origin", "fix/gp-meta1-x", "m.txt")
+        self.fx.run(self.lane, "gp-meta1", "--remote", "team|origin")
+        self.assertEqual(self.branch_of(self.lane), "fix/gp-meta1-x")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
 
     # --- refusals ----------------------------------------------------------------------------
 

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -394,6 +394,43 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertIn("clearing stale lock", proc.stderr)
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
 
+    def test_dirty_lane_on_the_same_bead_restarts_detached_at_its_tip(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        sha = commit(self.lane, "work.txt", "committed\n", "bead work")
+        (self.lane / "README.md").write_text("uncommitted edit\n", encoding="utf-8")
+        proc = self.fx.run(self.lane, "gp-old1")
+        asides = self.asides()
+        self.assertEqual(len(asides), 1)
+        self.assertEqual(self.branch_of(asides[0]), "gp-old1")
+        self.assertEqual((asides[0] / "README.md").read_text(encoding="utf-8"), "uncommitted edit\n")
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
+        self.assertIn("checked out at", proc.stderr)
+        self.assertEqual(proc.stdout.split()[2], "detached")
+
+    def test_base_head_fallback_means_the_rig_head_not_the_lane_head(self) -> None:
+        # No usable remote: BASE falls back to HEAD, which must be the rig's.
+        self.fx.run(self.lane, "gp-old1")
+        commit(self.lane, "ahead.txt", "x\n", "lane moved ahead")
+        proc = self.fx.run(self.lane, None, "--remote", "nosuch", "--no-fetch")
+        self.assertIn("new branches start at the rig root's HEAD", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        proc = self.fx.run(self.lane, "gp-new2", "--remote", "nosuch", "--no-fetch")
+        self.assertEqual(self.branch_of(self.lane), "gp-new2")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+
+    def test_ownerless_old_lock_is_reclaimed_but_a_fresh_one_is_respected(self) -> None:
+        self.lock_dir().mkdir()  # no pid file: a run died between mkdir and publishing
+        proc = self.fx.run(self.lane, "gp-abc1", check=False, env_extra={"WORKER_WORKTREE_LOCK_WAIT": "2"})
+        self.assertNotEqual(proc.returncode, 0)  # fresh: respected
+        os.utime(self.lock_dir(), (time.time() - 300, time.time() - 300))
+        proc = self.fx.run(self.lane, "gp-abc1")
+        self.assertIn("clearing stale lock", proc.stderr)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertFalse(self.lock_dir().exists())
+        self.assertEqual(sorted(self.fx.rig.joinpath(".git").glob("worker-worktree.lock*")), [])
+
     # --- refusals ----------------------------------------------------------------------------
 
     def test_workdir_inside_rig_root_is_refused_even_if_it_does_not_exist(self) -> None:
@@ -440,6 +477,17 @@ class WorkerWorktreeTests(unittest.TestCase):
         proc = self.fx.run(alias / "nested", "gp-abc1", check=False, mkdir=False)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("inside the rig root", proc.stderr)
+
+    def test_symlink_then_dot_dot_resolves_physically(self) -> None:
+        # city/tunnel -> rig/sub; "city/tunnel/../nested" is rig/nested on disk,
+        # which is where the kernel (and gc's MkdirAll) would put the session.
+        (self.fx.rig / "sub").mkdir()
+        (self.fx.city / "tunnel").symlink_to(self.fx.rig / "sub")
+        proc = self.fx.run(self.fx.city / "tunnel" / ".." / "nested", "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("inside the rig root", proc.stderr)
+        self.assertFalse((self.fx.rig / "nested").exists())
+        self.assertFalse((self.fx.city / "nested").exists())
 
     def test_flags_override_environment(self) -> None:
         lane = self.fx.city / "elsewhere"

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -2,7 +2,9 @@
 
 Each test builds a throwaway "remote" (bare repo) plus a rig checkout, then
 runs the script the way gc runs a pre_start command: cwd = the work dir,
-GC_DIR / GC_RIG_ROOT / GC_TRIGGER_BEAD_ID in the environment.
+GC_DIR / GC_RIG_ROOT / GC_TRIGGER_BEAD_ID in the environment. One row per
+contract line in the script header; the rig root is checked untouched after
+every case.
 """
 
 from __future__ import annotations
@@ -43,6 +45,7 @@ class Fixture:
         self.remote = root / "remote.git"
         self.rig = root / "rig"
         self.city = root / "city"
+        self.city.mkdir()
         subprocess.run(["git", "init", "--quiet", "--bare", "-b", "main", str(self.remote)], check=True)
         subprocess.run(["git", "init", "--quiet", "-b", "main", str(self.rig)], check=True)
         git(self.rig, "remote", "add", "origin", str(self.remote))
@@ -67,7 +70,7 @@ class Fixture:
         git(scratch, "push", "--quiet", "origin", name)
         return sha
 
-    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    def run(self, workdir: pathlib.Path, bead: str | None, *extra: str, check: bool = True, mkdir: bool = True) -> subprocess.CompletedProcess[str]:
         env = {
             **os.environ,
             "GC_DIR": str(workdir),
@@ -77,10 +80,11 @@ class Fixture:
         env.pop("GC_TRIGGER_BEAD_ID", None)
         if bead is not None:
             env["GC_TRIGGER_BEAD_ID"] = bead
-        workdir.mkdir(parents=True, exist_ok=True)  # gc MkdirAll's work_dir before pre_start
+        if mkdir:
+            workdir.mkdir(parents=True, exist_ok=True)  # gc MkdirAll's work_dir before pre_start
         proc = subprocess.run(
             ["sh", str(SCRIPT), *extra],
-            cwd=str(workdir),
+            cwd=str(workdir) if workdir.is_dir() else str(self.city),
             env=env,
             capture_output=True,
             text=True,
@@ -110,6 +114,12 @@ class WorkerWorktreeTests(unittest.TestCase):
             common = path / common
         self.assertEqual(common.resolve(), (self.fx.rig / ".git").resolve())
 
+    def asides(self, lane: pathlib.Path | None = None) -> list[pathlib.Path]:
+        lane = lane or self.lane
+        return sorted(lane.parent.glob(f"{lane.name}.aside-*"))
+
+    # --- fresh work dir -----------------------------------------------------------
+
     def test_empty_workdir_new_bead_creates_branch_from_base(self) -> None:
         proc = self.fx.run(self.lane, "gp-abc1")
         self.assert_is_worktree(self.lane)
@@ -118,6 +128,12 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertTrue((self.lane / "README.md").is_file())
         self.assertEqual(proc.stdout.split(), ["WORKTREE", str(self.lane), "gp-abc1", self.fx.main_sha[:7]])
 
+    def test_workdir_that_does_not_exist_yet_is_created(self) -> None:
+        proc = self.fx.run(self.lane, "gp-abc1", mkdir=False)
+        self.assert_is_worktree(self.lane)
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertEqual(proc.stdout.split()[1], str(self.lane))
+
     def test_rerun_is_idempotent(self) -> None:
         self.fx.run(self.lane, "gp-abc1")
         first = git(self.lane, "rev-parse", "HEAD")
@@ -125,6 +141,18 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
         self.assertEqual(git(self.lane, "rev-parse", "HEAD"), first)
         self.assertNotIn("WARN", proc.stderr)
+        self.assertEqual(self.asides(), [])
+
+    def test_new_branch_tracks_fresh_remote_tip_not_stale_local_main(self) -> None:
+        # The rig checkout lags: origin/main moves on, local main does not.
+        newer = self.fx.push_branch("main-advance", "newer.txt")
+        scratch = self.fx.root / "scratch-main-advance"
+        git(scratch, "push", "--quiet", "origin", "main-advance:main")
+        self.fx.run(self.lane, "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), newer)
+        self.assertEqual(git(self.fx.rig, "rev-parse", "main"), self.fx.main_sha)
+
+    # --- bead branch resolution -------------------------------------------------------
 
     def test_existing_remote_branch_named_for_bead_is_checked_out_and_tracked(self) -> None:
         sha = self.fx.push_branch("fix/gp-def2-resume-me")
@@ -134,8 +162,40 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(git(self.lane, "rev-parse", "--abbrev-ref", "@{upstream}"), "origin/fix/gp-def2-resume-me")
         self.assertTrue((self.lane / "feature.txt").is_file())
 
+    def test_bead_id_must_match_as_a_whole_token(self) -> None:
+        # gp-abc10 and xgp-abc1 are other beads; gp-abc1 has no branch yet.
+        self.fx.push_branch("fix/gp-abc10-unrelated", "a.txt")
+        self.fx.push_branch("xgp-abc1-unrelated", "b.txt")
+        self.fx.push_branch("gp-abc1x", "c.txt")
+        self.fx.run(self.lane, "gp-abc1")
+        self.assertEqual(self.branch_of(self.lane), "gp-abc1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+
+    def test_bead_id_matches_with_slash_dash_and_dot_boundaries(self) -> None:
+        for name, filename in (("feat/gp-tok1", "a.txt"),):
+            sha = self.fx.push_branch(name, filename)
+        self.fx.run(self.lane, "gp-tok1")
+        self.assertEqual(self.branch_of(self.lane), "feat/gp-tok1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
+
+    def test_bead_id_with_regex_characters_is_matched_literally(self) -> None:
+        self.fx.push_branch("gp-dotxx-other", "a.txt")  # would match 'gp-dot.x' as a regex
+        self.fx.run(self.lane, "gp-dot.x")
+        self.assertEqual(self.branch_of(self.lane), "gp-dot.x")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+
+    def test_ambiguous_bead_branches_fail_closed(self) -> None:
+        self.fx.push_branch("gp-amb1-first", "a.txt")
+        self.fx.push_branch("gp-amb1-second", "b.txt")
+        proc = self.fx.run(self.lane, "gp-amb1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("several branches", proc.stderr)
+        self.assertIn("gp-amb1-first", proc.stderr)
+        self.assertIn("gp-amb1-second", proc.stderr)
+        self.assertFalse((self.lane / ".git").exists())
+
     def test_bead_branch_checked_out_elsewhere_is_not_stolen(self) -> None:
-        other = self.fx.root / "other-worktree"
+        other = self.fx.root / "other worktree"  # a space: the porcelain parser must keep it
         git(self.fx.rig, "worktree", "add", "--quiet", "-b", "gp-ghi3-elsewhere", str(other), "origin/main")
         sha = commit(other, "elsewhere.txt", "x\n", "elsewhere work")
         proc = self.fx.run(self.lane, "gp-ghi3")
@@ -143,8 +203,19 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
         self.assertIn("WARN", proc.stderr)
         self.assertIn(str(other), proc.stderr)
+        self.assertNotIn("work in that worktree", proc.stderr)
         self.assertEqual(self.branch_of(other), "gp-ghi3-elsewhere")
         self.assertEqual(proc.stdout.split()[2], "detached")
+
+    def test_rerun_under_a_path_with_spaces_keeps_its_own_branch(self) -> None:
+        lane = self.fx.city / "lanes with spaces" / "lane worker"
+        self.fx.run(lane, "gp-spc1")
+        self.assertEqual(self.branch_of(lane), "gp-spc1")
+        proc = self.fx.run(lane, "gp-spc1")
+        self.assertEqual(self.branch_of(lane), "gp-spc1")  # not mis-detected as "elsewhere" and detached
+        self.assertNotIn("WARN", proc.stderr)
+
+    # --- existing lane ------------------------------------------------------------------
 
     def test_clean_lane_on_old_bead_switches_to_new_bead(self) -> None:
         self.fx.run(self.lane, "gp-old1")
@@ -157,7 +228,7 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
         self.assertFalse((self.lane / "old.txt").exists())
         self.assertTrue((self.lane / ".agents" / "skills.txt").is_file())
-        self.assertNotIn("aside", proc.stderr)
+        self.assertEqual(self.asides(), [])
         # The old bead's branch and commit survive.
         self.assertTrue(git(self.fx.rig, "rev-parse", "--verify", "gp-old1"))
 
@@ -166,7 +237,7 @@ class WorkerWorktreeTests(unittest.TestCase):
         (self.lane / "README.md").write_text("uncommitted edit\n", encoding="utf-8")
         proc = self.fx.run(self.lane, "gp-new2")
         self.assertIn("moved aside", proc.stderr)
-        asides = sorted(self.lane.parent.glob("lane-worker.aside-*"))
+        asides = self.asides()
         self.assertEqual(len(asides), 1)
         self.assertEqual((asides[0] / "README.md").read_text(encoding="utf-8"), "uncommitted edit\n")
         self.assertEqual(self.branch_of(asides[0]), "gp-old1")
@@ -177,26 +248,58 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertIn(str(asides[0]), listing)
         self.assertIn(str(self.lane), listing)
 
+    def test_switch_that_would_overwrite_an_ignored_file_moves_the_lane_aside(self) -> None:
+        # The target branch tracks build/out.txt; the lane has an ignored local
+        # file at that path. git switch would silently clobber it.
+        sha = self.fx.push_branch("gp-ign2-tracks-build", "build-out.txt")
+        scratch = self.fx.root / "scratch-gp-ign2-tracks-build"
+        (scratch / "build").mkdir()
+        (scratch / "build" / "out.txt").write_text("tracked\n", encoding="utf-8")
+        git(scratch, "add", "build/out.txt")
+        git(scratch, "-c", "user.name=t", "-c", "user.email=t@example.invalid", "commit", "--quiet", "-m", "track build/out.txt")
+        git(scratch, "push", "--quiet", "origin", "gp-ign2-tracks-build")
+        self.fx.run(self.lane, "gp-old1")
+        # per-worktree exclude lives in the worktree's git dir (.git here is a file)
+        exclude = pathlib.Path(git(self.lane, "rev-parse", "--git-path", "info/exclude"))
+        if not exclude.is_absolute():
+            exclude = self.lane / exclude
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        exclude.write_text("build/\n", encoding="utf-8")
+        (self.lane / "build").mkdir()
+        (self.lane / "build" / "out.txt").write_text("local artifact, ignored\n", encoding="utf-8")
+        self.assertEqual(git(self.lane, "status", "--porcelain"), "")
+        proc = self.fx.run(self.lane, "gp-ign2")
+        self.assertIn("moved aside", proc.stderr)
+        asides = self.asides()
+        self.assertEqual(len(asides), 1)
+        self.assertEqual((asides[0] / "build" / "out.txt").read_text(encoding="utf-8"), "local artifact, ignored\n")
+        self.assertEqual(self.branch_of(self.lane), "gp-ign2-tracks-build")
+        self.assertEqual((self.lane / "build" / "out.txt").read_text(encoding="utf-8"), "tracked\n")
+        self.assertNotEqual(sha, "")
+
+    def test_locked_worktree_that_needs_moving_fails_closed(self) -> None:
+        self.fx.run(self.lane, "gp-old1")
+        (self.lane / "README.md").write_text("uncommitted edit\n", encoding="utf-8")
+        git(self.fx.rig, "worktree", "lock", str(self.lane))
+        proc = self.fx.run(self.lane, "gp-new2", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("refused to move", proc.stderr)
+        self.assertEqual(self.asides(), [])
+        self.assertEqual(self.branch_of(self.lane), "gp-old1")
+        self.assertEqual((self.lane / "README.md").read_text(encoding="utf-8"), "uncommitted edit\n")
+
     def test_nonempty_non_worktree_dir_is_moved_aside(self) -> None:
         self.lane.mkdir(parents=True)
         (self.lane / "junk.txt").write_text("keep me\n", encoding="utf-8")
         proc = self.fx.run(self.lane, "gp-abc1")
         self.assertIn("moved aside", proc.stderr)
-        asides = sorted(self.lane.parent.glob("lane-worker.aside-*"))
+        asides = self.asides()
         self.assertEqual(len(asides), 1)
         self.assertEqual((asides[0] / "junk.txt").read_text(encoding="utf-8"), "keep me\n")
         self.assert_is_worktree(self.lane)
         self.assertEqual(self.branch_of(self.lane), "gp-abc1")
 
-    def test_ambiguous_bead_branches_fail_closed(self) -> None:
-        self.fx.push_branch("gp-amb1-first", "a.txt")
-        self.fx.push_branch("gp-amb1-second", "b.txt")
-        proc = self.fx.run(self.lane, "gp-amb1", check=False)
-        self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("several branches", proc.stderr)
-        self.assertIn("gp-amb1-first", proc.stderr)
-        self.assertIn("gp-amb1-second", proc.stderr)
-        self.assertFalse((self.lane / ".git").exists())
+    # --- no bead ----------------------------------------------------------------------------
 
     def test_no_bead_leaves_a_detached_worktree_at_base(self) -> None:
         proc = self.fx.run(self.lane, None)
@@ -205,28 +308,46 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
         self.assertEqual(proc.stdout.split()[2], "detached")
 
-    def test_no_bead_does_not_move_a_lane_off_its_branch(self) -> None:
+    def test_no_bead_detaches_a_lane_that_was_on_a_branch_and_keeps_the_branch(self) -> None:
         self.fx.run(self.lane, "gp-old1")
+        sha = commit(self.lane, "old.txt", "old\n", "old bead work")
         self.fx.run(self.lane, None)
-        self.assertEqual(self.branch_of(self.lane), "gp-old1")
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), self.fx.main_sha)
+        self.assertEqual(git(self.fx.rig, "rev-parse", "gp-old1"), sha)
+        self.assertEqual(self.asides(), [])
 
-    def test_new_branch_tracks_fresh_remote_tip_not_stale_local_main(self) -> None:
-        # The rig checkout lags: origin/main moves on, local main does not.
-        newer = self.fx.push_branch("main-advance", "newer.txt")
-        scratch = self.fx.root / "scratch-main-advance"
-        git(scratch, "push", "--quiet", "origin", "main-advance:main")
-        self.fx.run(self.lane, "gp-abc1")
-        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), newer)
-        self.assertEqual(git(self.fx.rig, "rev-parse", "main"), self.fx.main_sha)
+    def test_no_bead_rerun_on_a_detached_lane_is_a_no_op(self) -> None:
+        self.fx.run(self.lane, None)
+        proc = self.fx.run(self.lane, None)
+        self.assertEqual(self.branch_of(self.lane), "HEAD")
+        self.assertNotIn("WARN", proc.stderr)
 
-    def test_workdir_inside_rig_root_is_refused(self) -> None:
+    # --- refusals ----------------------------------------------------------------------------
+
+    def test_workdir_inside_rig_root_is_refused_even_if_it_does_not_exist(self) -> None:
         inside = self.fx.rig / "nested"
-        proc = self.fx.run(inside, "gp-abc1", check=False)
+        proc = self.fx.run(inside, "gp-abc1", check=False, mkdir=False)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("inside the rig root", proc.stderr)
+        self.assertFalse(inside.exists())
         proc = self.fx.run(self.fx.rig, "gp-abc1", check=False)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("is the rig root", proc.stderr)
+
+    def test_workdir_that_is_an_ancestor_of_the_rig_root_is_refused(self) -> None:
+        proc = self.fx.run(self.fx.root, "gp-abc1", check=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("ancestor of the rig root", proc.stderr)
+        self.assertEqual(self.asides(self.fx.root), [])
+        self.assertTrue(self.fx.rig.is_dir())
+
+    def test_symlink_alias_of_the_rig_root_is_refused(self) -> None:
+        alias = self.fx.root / "rig-alias"
+        alias.symlink_to(self.fx.rig)
+        proc = self.fx.run(alias / "nested", "gp-abc1", check=False, mkdir=False)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("inside the rig root", proc.stderr)
 
     def test_flags_override_environment(self) -> None:
         lane = self.fx.city / "elsewhere"

--- a/gascity/tests/test_worker_worktree.py
+++ b/gascity/tests/test_worker_worktree.py
@@ -216,6 +216,25 @@ class WorkerWorktreeTests(unittest.TestCase):
         self.assertEqual(self.branch_of(other), "gp-ghi3-elsewhere")
         self.assertEqual(proc.stdout.split()[2], "detached")
 
+    def test_existing_local_branch_left_by_a_detached_lane_is_checked_out(self) -> None:
+        # The do-work handoff: the run operator's lane created the item's branch,
+        # committed on it, then detached (git allows one worktree per branch).
+        # The next role's lane reuses that LOCAL branch, which was never pushed:
+        # nothing is created from the base, no WARN, the operator's lane is untouched.
+        operator = self.fx.city / ".worktrees" / "rig" / "lane-operator"
+        self.fx.run(operator, "gp-hand1")
+        sha = commit(operator, "item.txt", "prepared\n", "item branch work")
+        git(operator, "switch", "--detach")
+        proc = self.fx.run(self.lane, "gp-hand1")
+        self.assertEqual(self.branch_of(self.lane), "gp-hand1")
+        self.assertEqual(git(self.lane, "rev-parse", "HEAD"), sha)
+        self.assertTrue((self.lane / "item.txt").is_file())
+        self.assertNotIn("WARN", proc.stderr)
+        self.assertEqual(proc.stdout.split()[2], "gp-hand1")
+        self.assertEqual(self.branch_of(operator), "HEAD")  # the operator's lane stays detached
+        self.assertEqual(git(operator, "rev-parse", "HEAD"), sha)
+        self.assertEqual(self.asides(), [])
+
     def test_rerun_under_a_path_with_spaces_keeps_its_own_branch(self) -> None:
         lane = self.fx.city / "lanes with spaces" / "lane worker"
         self.fx.run(lane, "gp-spc1")

--- a/tests/test_gc_role_prompt_integration.py
+++ b/tests/test_gc_role_prompt_integration.py
@@ -190,6 +190,8 @@ def assert_clean_worker_render(prompt: str, persona_heading: str) -> None:
     assert "CLAIMED_ROOT_BEAD_ID" in prompt
     assert "CLAIMED_CONTINUATION_GROUP" in prompt
     assert 'gc bd update "$CLAIMED_BEAD_ID"' in prompt
+    assert "An absent key is an empty value, never a failed claim." in prompt
+    assert prompt.count("## Workspace") == 1
     assert "An empty continuation group is a hard session boundary" in prompt
 
 

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -1,0 +1,60 @@
+"""Static checks on the shared `gc-role-worker` template fragment.
+
+The rendered-prompt integration tests need a real gc binary (GC_TEST_BIN);
+these run everywhere and pin the fragment text every role worker inherits.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRAGMENT = REPO_ROOT / "gascity" / "template-fragments" / "gc-role-worker.template.md"
+
+
+def fragment() -> str:
+    return FRAGMENT.read_text(encoding="utf-8")
+
+
+def test_fragment_defines_exactly_one_template() -> None:
+    text = fragment()
+    assert text.count('{{ define "gc-role-worker" -}}') == 1
+    assert text.count("{{- end }}") == 1
+    assert text.count("# GC Role Worker") == 1
+
+
+def test_claim_section_tolerates_omitted_lifecycle_keys() -> None:
+    text = fragment()
+    claim = text.split("## Claim", 1)[1].split("## Workspace", 1)[0]
+    assert "CLAIMED_ROOT_BEAD_ID" in claim
+    assert "CLAIMED_CONTINUATION_GROUP" in claim
+    assert "An absent key is an empty value, never a failed claim." in claim
+
+
+def test_workspace_section_sits_between_claim_and_close() -> None:
+    text = fragment()
+    claim_at = text.index("## Claim")
+    workspace_at = text.index("## Workspace")
+    close_at = text.index("## Close")
+    assert claim_at < workspace_at < close_at
+    workspace = text[workspace_at:close_at]
+    assert "$GC_DIR" in workspace
+    assert "worker-worktree.sh" in workspace
+    assert "<city>/.worktrees/<rig>/<bead>" in workspace
+    assert "check that branch out in the new worktree" in workspace
+    assert "--set-metadata 'work_dir=<absolute worktree path>'" in workspace
+    assert "--set-metadata 'gc.work_branch=<branch>'" in workspace
+
+
+def test_workspace_section_never_names_the_rig_root_as_a_place_to_work() -> None:
+    workspace = fragment().split("## Workspace", 1)[1].split("## Close", 1)[0]
+    assert "rig root and the rig forbids working there" in workspace
+    assert "cd " not in workspace
+
+
+def test_worker_worktree_script_is_shipped_and_executable() -> None:
+    script = REPO_ROOT / "gascity" / "assets" / "scripts" / "worker-worktree.sh"
+    assert script.is_file()
+    assert script.stat().st_mode & 0o111, "worker-worktree.sh must be executable"
+    head = script.read_text(encoding="utf-8").splitlines()[0]
+    assert head == "#!/bin/sh"

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -42,6 +42,8 @@ def test_workspace_section_sits_between_claim_and_close() -> None:
     assert "worker-worktree.sh" in workspace
     assert "<city>/.worktrees/<rig>/<bead>" in workspace
     assert "check that branch out in the new worktree" in workspace
+    assert "if `git branch --show-current` prints" in workspace
+    assert "restamp it when they differ" in workspace
     assert "--set-metadata 'work_dir=<absolute worktree path>'" in workspace
     assert "--set-metadata 'gc.work_branch=<branch>'" in workspace
 

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -112,8 +112,7 @@ def test_workspace_fallback_covers_every_unconfigured_role() -> None:
     flat = " ".join(fallback.split())
     for clause in (
         "If `$GC_DIR` is the rig root, this role has no `work_dir` in your city: create your worktree under",
-        "`<city>/.worktrees/<rig>/<bead>` from `origin/<default branch>`",
-        "(check out the bead's branch if it already exists)",
+        "`<city>/.worktrees/<rig>/<bead>` (check out the bead's branch if it already exists)",
         "work there, and mail the mayor that this role needs a lane",
         "(`work_dir` + `pre_start`, see README, Worker workspaces)",
     ):
@@ -125,6 +124,63 @@ def test_workspace_fallback_covers_every_unconfigured_role() -> None:
     # The fallback never fires where lanes are configured: no other paragraph
     # of the Workspace section is conditional on the rig root.
     assert sum(para.startswith("If ") for para in paragraphs(workspace)) == 1
+
+
+SCRIPT = REPO_ROOT / "gascity" / "assets" / "scripts" / "worker-worktree.sh"
+WORKFLOWS = REPO_ROOT / "gascity" / "assets" / "workflows"
+FORMULAS = REPO_ROOT / "gascity" / "formulas"
+
+
+def script_base_order() -> list[str]:
+    """The `--base` resolution order worker-worktree.sh implements, read from
+    the script itself so the prompt cannot drift from it: the remote refs it
+    probes, in source order, then its literal HEAD fallback."""
+    block = SCRIPT.read_text(encoding="utf-8").split('if [ -z "$BASE" ]; then', 1)[1].split("BASE_SHA=", 1)[0]
+    probes = re.findall(r"refs/remotes/\$REMOTE/(HEAD|main|master)", block)
+    assert 'BASE="HEAD"' in block, "the script no longer falls back to the rig's HEAD"
+    return [f"<remote>/{name}" for name in probes] + ["HEAD"]
+
+
+def test_workspace_fallback_resolves_its_base_and_needs_no_origin_remote() -> None:
+    """Gate r7 (round 8): the fallback required `origin/<default branch>`, so a
+    local-only rig, or one whose remote is not named origin, could never get a
+    workspace under a paragraph that now covers every unconfigured role. The
+    fallback RESOLVES the base in worker-worktree.sh's order and ends at the
+    rig checkout's HEAD; the order is read from the script, not retyped."""
+    fallback = [para for para in paragraphs(workspace_section()) if para.startswith(FALLBACK_OPENER)][0]
+    flat = " ".join(fallback.split())
+    order = script_base_order()
+    assert order == ["<remote>/HEAD", "<remote>/main", "<remote>/master", "HEAD"]
+    # Every candidate is named, in the script's order, after the sentence
+    # that says the base is resolved; the last one is the rig's own HEAD.
+    resolve_at = flat.index("Resolve the base of a new branch, never assume it")
+    positions = [flat.index(f"`{ref}`", resolve_at) for ref in order[:-1]]
+    positions.append(flat.index("else the rig checkout's current `HEAD`", resolve_at))
+    assert positions == sorted(positions), flat
+    for clause in (
+        "in the order `worker-worktree.sh` uses",
+        "the remote's default branch when the rig has a remote",
+        "when the remote has another name, that name from `git -C <rig root> remote`",
+        "Pin the base to a commit in the rig",
+        "create the worktree from that commit",
+        "This fallback never fails for lack of a remote",
+        "never writes into the rig checkout",
+        "the checkout's HEAD and files do not move",
+    ):
+        assert clause in flat, f"fallback paragraph lacks: {clause!r}"
+    # No bare origin requirement anywhere a worker reads: the fragment, every
+    # role prompt, every workflow step, every formula (the sweep, pinned).
+    consumers = [
+        FRAGMENT,
+        *sorted((REPO_ROOT / "gascity" / "roles" / "agents").glob("*/prompt.template.md")),
+        *sorted(WORKFLOWS.rglob("*.md")),
+        *sorted(FORMULAS.glob("*.toml")),
+    ]
+    assert len(consumers) > 20
+    for path in consumers:
+        text = path.read_text(encoding="utf-8")
+        for bare in ("origin/", "<default branch>"):
+            assert bare not in text, f"{path.relative_to(REPO_ROOT)} assumes a remote named origin: {bare!r}"
 
 
 def test_worker_worktree_script_is_shipped_and_executable() -> None:

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -6,6 +6,7 @@ these run everywhere and pin the fragment text every role worker inherits.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -60,18 +61,60 @@ HUNTING_RULES = (
     "If you start in the rig root",
 )
 
+FALLBACK_OPENER = "If `$GC_DIR` is the rig root"
+
+
+def paragraphs(text: str) -> list[str]:
+    """Blank-line separated paragraphs of a prompt, whitespace-stripped."""
+    return [para.strip() for para in re.split(r"\n[ \t]*\n", text) if para.strip()]
+
+
+def workspace_section() -> str:
+    return fragment().split("## Workspace", 1)[1].split("## Close", 1)[0]
+
 
 def test_workers_never_choose_or_create_their_workspace() -> None:
-    """gc chooses the workspace (agent work_dir + pre_start); no role prompt
-    tells a worker to go and make its own worktree."""
-    workspace = fragment().split("## Workspace", 1)[1].split("## Close", 1)[0]
+    """gc chooses the workspace (agent work_dir + pre_start). The PRIMARY text
+    of every role prompt never tells a worker to go and make its own worktree;
+    the hunting phrases may appear only inside the one conditional fallback
+    paragraph (see test_workspace_fallback_is_conditional_and_mails_the_mayor)."""
+    workspace = workspace_section()
     assert "You never pick, create, or hunt for\na workspace" in workspace
     prompts = [FRAGMENT, *sorted((REPO_ROOT / "gascity" / "roles" / "agents").glob("*/prompt.template.md"))]
     assert len(prompts) > 1
     for path in prompts:
-        text = path.read_text(encoding="utf-8")
-        for rule in HUNTING_RULES:
-            assert rule not in text, f"{path.relative_to(REPO_ROOT)} still tells the worker to hunt for a worktree: {rule!r}"
+        for para in paragraphs(path.read_text(encoding="utf-8")):
+            if para.startswith(FALLBACK_OPENER):
+                continue
+            for rule in HUNTING_RULES:
+                assert rule not in para, (
+                    f"{path.relative_to(REPO_ROOT)} tells the worker to hunt for a worktree "
+                    f"outside the conditional fallback: {rule!r} in {para[:60]!r}"
+                )
+
+
+def test_workspace_fallback_is_conditional_and_mails_the_mayor() -> None:
+    """One fallback paragraph for a city that gave the role no work_dir: it is
+    conditional on $GC_DIR being the rig root, sits after the primary text, and
+    tells the worker to mail the mayor for a lane."""
+    workspace = workspace_section()
+    fallbacks = [para for para in paragraphs(workspace) if para.startswith(FALLBACK_OPENER)]
+    assert len(fallbacks) == 1, "exactly one conditional fallback paragraph"
+    fallback = fallbacks[0]
+    assert workspace.index("You never pick, create, or hunt for") < workspace.index(FALLBACK_OPENER)
+    flat = " ".join(fallback.split())
+    for clause in (
+        "If `$GC_DIR` is the rig root, this role has no `work_dir` in your city.",
+        "When the rig's rules forbid working there, create your worktree under",
+        "`<city>/.worktrees/<rig>/<bead>` from `origin/<default branch>`",
+        "(check out the bead's branch if it already exists)",
+        "work there, and mail the mayor that this role needs a lane",
+        "(`work_dir` + `pre_start`, see README, Worker workspaces)",
+    ):
+        assert clause in flat, f"fallback paragraph lacks: {clause!r}"
+    # The fallback never fires where lanes are configured: no other paragraph
+    # of the Workspace section is conditional on the rig root.
+    assert sum(para.startswith("If ") for para in paragraphs(workspace)) == 1
 
 
 def test_worker_worktree_script_is_shipped_and_executable() -> None:

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -168,19 +168,27 @@ def test_workspace_fallback_resolves_its_base_and_needs_no_origin_remote() -> No
         "the checkout's HEAD and files do not move",
     ):
         assert clause in flat, f"fallback paragraph lacks: {clause!r}"
-    # No bare origin requirement anywhere a worker reads: the fragment, every
-    # role prompt, every workflow step, every formula (the sweep, pinned).
-    consumers = [
-        FRAGMENT,
-        *sorted((REPO_ROOT / "gascity" / "roles" / "agents").glob("*/prompt.template.md")),
-        *sorted(WORKFLOWS.rglob("*.md")),
-        *sorted(FORMULAS.glob("*.toml")),
-    ]
-    assert len(consumers) > 20
-    for path in consumers:
+    # The sweep, pinned. The fragment and every role prompt name no `origin/`
+    # at all. A workflow step or formula may name `origin/` only where it
+    # RESOLVES the remote's HEAD itself (`git symbolic-ref
+    # refs/remotes/origin/HEAD`; upstream's do-work prepare-worktree step 5
+    # does, and fails closed without it by its own tested design, see
+    # tests/test_default_branch_resolution.py there) and never as the
+    # `origin/<default branch>` assumption this round removed.
+    prompts = [FRAGMENT, *sorted((REPO_ROOT / "gascity" / "roles" / "agents").glob("*/prompt.template.md"))]
+    steps = [*sorted(WORKFLOWS.rglob("*.md")), *sorted(FORMULAS.glob("*.toml"))]
+    assert len(prompts) > 1 and len(steps) > 20
+    for path in prompts:
         text = path.read_text(encoding="utf-8")
         for bare in ("origin/", "<default branch>"):
             assert bare not in text, f"{path.relative_to(REPO_ROOT)} assumes a remote named origin: {bare!r}"
+    for path in steps:
+        text = path.read_text(encoding="utf-8")
+        assert "origin/<default branch>" not in text, f"{path.relative_to(REPO_ROOT)} assumes `origin/<default branch>`"
+        if "origin/" in text:
+            assert "symbolic-ref" in text and "refs/remotes/origin/HEAD" in text, (
+                f"{path.relative_to(REPO_ROOT)} names origin/ without resolving refs/remotes/origin/HEAD"
+            )
 
 
 def test_worker_worktree_script_is_shipped_and_executable() -> None:

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -40,8 +40,6 @@ def test_workspace_section_sits_between_claim_and_close() -> None:
     workspace = text[workspace_at:close_at]
     assert "$GC_DIR" in workspace
     assert "worker-worktree.sh" in workspace
-    assert "<city>/.worktrees/<rig>/<bead>" in workspace
-    assert "check that branch out in the new worktree" in workspace
     assert "if `git branch --show-current` prints" in workspace
     assert "restamp it when they differ" in workspace
     assert "--set-metadata 'work_dir=<absolute worktree path>'" in workspace
@@ -50,8 +48,30 @@ def test_workspace_section_sits_between_claim_and_close() -> None:
 
 def test_workspace_section_never_names_the_rig_root_as_a_place_to_work() -> None:
     workspace = fragment().split("## Workspace", 1)[1].split("## Close", 1)[0]
-    assert "rig root and the rig forbids working there" in workspace
+    assert "never work in the rig root" in workspace
+    assert "the rig root is a human\ncheckout" in workspace
     assert "cd " not in workspace
+
+
+HUNTING_RULES = (
+    ".worktrees/<rig>/<bead>",
+    "create your\nown worktree",
+    "create your own worktree",
+    "If you start in the rig root",
+)
+
+
+def test_workers_never_choose_or_create_their_workspace() -> None:
+    """gc chooses the workspace (agent work_dir + pre_start); no role prompt
+    tells a worker to go and make its own worktree."""
+    workspace = fragment().split("## Workspace", 1)[1].split("## Close", 1)[0]
+    assert "You never pick, create, or hunt for\na workspace" in workspace
+    prompts = [FRAGMENT, *sorted((REPO_ROOT / "gascity" / "roles" / "agents").glob("*/prompt.template.md"))]
+    assert len(prompts) > 1
+    for path in prompts:
+        text = path.read_text(encoding="utf-8")
+        for rule in HUNTING_RULES:
+            assert rule not in text, f"{path.relative_to(REPO_ROOT)} still tells the worker to hunt for a worktree: {rule!r}"
 
 
 def test_worker_worktree_script_is_shipped_and_executable() -> None:

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -77,7 +77,7 @@ def test_workers_never_choose_or_create_their_workspace() -> None:
     """gc chooses the workspace (agent work_dir + pre_start). The PRIMARY text
     of every role prompt never tells a worker to go and make its own worktree;
     the hunting phrases may appear only inside the one conditional fallback
-    paragraph (see test_workspace_fallback_is_conditional_and_mails_the_mayor)."""
+    paragraph (see test_workspace_fallback_covers_every_unconfigured_role)."""
     workspace = workspace_section()
     assert "You never pick, create, or hunt for\na workspace" in workspace
     prompts = [FRAGMENT, *sorted((REPO_ROOT / "gascity" / "roles" / "agents").glob("*/prompt.template.md"))]
@@ -93,25 +93,35 @@ def test_workers_never_choose_or_create_their_workspace() -> None:
                 )
 
 
-def test_workspace_fallback_is_conditional_and_mails_the_mayor() -> None:
-    """One fallback paragraph for a city that gave the role no work_dir: it is
-    conditional on $GC_DIR being the rig root, sits after the primary text, and
-    tells the worker to mail the mayor for a lane."""
+def test_workspace_fallback_covers_every_unconfigured_role() -> None:
+    """One fallback paragraph for a city that gave the role no work_dir. It is
+    conditional ONLY on $GC_DIR being the rig root: the pack ships every role
+    without work_dir/pre_start, so in a default installation a role starts in
+    the rig root, is told never to work there, and needs one permitted place
+    (gate r3 M2). Round 2 keyed the fallback on the rig's rules forbidding
+    root work, which left a rig without such a rule no workspace at all; that
+    condition is gone. The paragraph sits after the primary text and tells the
+    worker to mail the mayor for a lane."""
     workspace = workspace_section()
     fallbacks = [para for para in paragraphs(workspace) if para.startswith(FALLBACK_OPENER)]
     assert len(fallbacks) == 1, "exactly one conditional fallback paragraph"
     fallback = fallbacks[0]
     assert workspace.index("You never pick, create, or hunt for") < workspace.index(FALLBACK_OPENER)
+    # The primary text still describes the configured case.
+    assert "never work in the rig root" in workspace
     flat = " ".join(fallback.split())
     for clause in (
-        "If `$GC_DIR` is the rig root, this role has no `work_dir` in your city.",
-        "When the rig's rules forbid working there, create your worktree under",
+        "If `$GC_DIR` is the rig root, this role has no `work_dir` in your city: create your worktree under",
         "`<city>/.worktrees/<rig>/<bead>` from `origin/<default branch>`",
         "(check out the bead's branch if it already exists)",
         "work there, and mail the mayor that this role needs a lane",
         "(`work_dir` + `pre_start`, see README, Worker workspaces)",
     ):
         assert clause in flat, f"fallback paragraph lacks: {clause!r}"
+    # The only condition is the rig root; nothing in the Workspace section keys
+    # the fallback on the rig's rules.
+    for gone in ("When the rig's rules forbid", "rules forbid", "forbid working there"):
+        assert gone not in " ".join(workspace.split()), f"round-2 condition still present: {gone!r}"
     # The fallback never fires where lanes are configured: no other paragraph
     # of the Workspace section is conditional on the rig root.
     assert sum(para.startswith("If ") for para in paragraphs(workspace)) == 1

--- a/tests/test_gc_role_worker_fragment.py
+++ b/tests/test_gc_role_worker_fragment.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FRAGMENT = REPO_ROOT / "gascity" / "template-fragments" / "gc-role-worker.template.md"
+README = REPO_ROOT / "gascity" / "README.md"
 
 
 def fragment() -> str:
@@ -58,10 +59,11 @@ HUNTING_RULES = (
     ".worktrees/<rig>/<bead>",
     "create your\nown worktree",
     "create your own worktree",
+    "create your worktree",
     "If you start in the rig root",
+    "If `$GC_DIR` is the rig root",
+    "worktree add",
 )
-
-FALLBACK_OPENER = "If `$GC_DIR` is the rig root"
 
 
 def paragraphs(text: str) -> list[str]:
@@ -73,122 +75,104 @@ def workspace_section() -> str:
     return fragment().split("## Workspace", 1)[1].split("## Close", 1)[0]
 
 
+def role_prompts() -> list[Path]:
+    return [FRAGMENT, *sorted((REPO_ROOT / "gascity" / "roles" / "agents").glob("*/prompt.template.md"))]
+
+
 def test_workers_never_choose_or_create_their_workspace() -> None:
-    """gc chooses the workspace (agent work_dir + pre_start). The PRIMARY text
-    of every role prompt never tells a worker to go and make its own worktree;
-    the hunting phrases may appear only inside the one conditional fallback
-    paragraph (see test_workspace_fallback_covers_every_unconfigured_role)."""
+    """gc chooses the workspace (agent work_dir + pre_start). No role prompt
+    tells a worker to go and make its own worktree, in ANY paragraph: the one
+    conditional fallback that rounds 2 to 8 exempted here is gone (round 9,
+    see test_session_outside_a_lane_creates_no_worktree_and_fails_closed_no_lane)."""
     workspace = workspace_section()
     assert "You never pick, create, or hunt for\na workspace" in workspace
-    prompts = [FRAGMENT, *sorted((REPO_ROOT / "gascity" / "roles" / "agents").glob("*/prompt.template.md"))]
+    prompts = role_prompts()
     assert len(prompts) > 1
     for path in prompts:
         for para in paragraphs(path.read_text(encoding="utf-8")):
-            if para.startswith(FALLBACK_OPENER):
-                continue
             for rule in HUNTING_RULES:
                 assert rule not in para, (
-                    f"{path.relative_to(REPO_ROOT)} tells the worker to hunt for a worktree "
-                    f"outside the conditional fallback: {rule!r} in {para[:60]!r}"
+                    f"{path.relative_to(REPO_ROOT)} tells the worker to make or hunt for a worktree: "
+                    f"{rule!r} in {para[:60]!r}"
                 )
 
 
-def test_workspace_fallback_covers_every_unconfigured_role() -> None:
-    """One fallback paragraph for a city that gave the role no work_dir. It is
-    conditional ONLY on $GC_DIR being the rig root: the pack ships every role
-    without work_dir/pre_start, so in a default installation a role starts in
-    the rig root, is told never to work there, and needs one permitted place
-    (gate r3 M2). Round 2 keyed the fallback on the rig's rules forbidding
-    root work, which left a rig without such a rule no workspace at all; that
-    condition is gone. The paragraph sits after the primary text and tells the
-    worker to mail the mayor for a lane."""
+def test_session_outside_a_lane_creates_no_worktree_and_fails_closed_no_lane() -> None:
+    """Round 9 (Afik, 9/9 22:28 CT: "drop the fallback if we don't use it").
+    Rounds 2, 3, 4, 7 and 8 each patched one paragraph that had a role the
+    city gave no lane make its own worktree; no citadel dispatch takes that
+    path since the city half went live. The fragment now carries NO
+    worktree-creating instruction anywhere in its role-session text (no `git
+    worktree add` verb, no `.worktrees/...` path to make, no base to resolve),
+    and ONE paragraph says what a session outside a gc-made lane does: the
+    three-part boundary test, then read by `git show` / `git log -1` only,
+    and `gc.outcome=fail` + `gc.failure_class=no-lane` naming the lane the
+    city must give the role. Grep-driven over the fragment and the README."""
+    text = fragment()
+    flat = " ".join(text.split())
+    # No worktree-creating verb and no trace of the fallback, anywhere in the fragment.
+    for gone in (
+        "worktree add",
+        ".worktrees/<rig>/<bead>",
+        "create your worktree",
+        "mail the mayor that this role needs a lane",
+        "Resolve the base of a new branch",
+        "<remote>/HEAD",
+        "<remote>/main",
+        "<remote>/master",
+        "rev-parse --verify '<base>^{commit}'",
+        "This fallback never fails",
+        "If `$GC_DIR` is the rig root",
+    ):
+        assert gone not in flat, f"the fragment still carries the lane-less fallback: {gone!r}"
+    assert "fallback" not in flat.lower()
+    assert not any(para.startswith("If ") for para in paragraphs(workspace_section())), (
+        "no conditional workspace paragraph: there is no fallback to condition"
+    )
+
+    # ONE paragraph for a session outside a lane, after the primary text.
     workspace = workspace_section()
-    fallbacks = [para for para in paragraphs(workspace) if para.startswith(FALLBACK_OPENER)]
-    assert len(fallbacks) == 1, "exactly one conditional fallback paragraph"
-    fallback = fallbacks[0]
-    assert workspace.index("You never pick, create, or hunt for") < workspace.index(FALLBACK_OPENER)
-    # The primary text still describes the configured case.
-    assert "never work in the rig root" in workspace
-    flat = " ".join(fallback.split())
+    opener = "A session outside a gc-made lane has no lane"
+    no_lane = [para for para in paragraphs(workspace) if para.startswith(opener)]
+    assert len(no_lane) == 1, "exactly one no-lane paragraph"
+    para = " ".join(no_lane[0].split())
+    assert workspace.index("You never pick, create, or hunt for") < workspace.index(opener)
+    # The three-part boundary test, in order, then the rule that depends on it.
+    probes = (
+        '`git -C "$GC_DIR" rev-parse --show-toplevel` is `$GC_DIR` itself',
+        "that top-level is neither the rig root (`$GC_RIG_ROOT`) nor inside it",
+        '`git -C "$GC_DIR" rev-parse --git-common-dir` is the rig root\'s `.git`',
+    )
+    positions = [para.index(probe) for probe in probes]
+    assert positions == sorted(positions), para
     for clause in (
-        "If `$GC_DIR` is the rig root, this role has no `work_dir` in your city: create your worktree under",
-        "`<city>/.worktrees/<rig>/<bead>` (check out the bead's branch if it already exists)",
-        "work there, and mail the mayor that this role needs a lane",
-        "(`work_dir` + `pre_start`, see README, Worker workspaces)",
+        "this role has no `work_dir` in your city",
+        "Prove the lane before you write, with the three-part boundary test",
+        "When any part fails (`$GC_DIR` is the rig root, a directory inside it, or a checkout of another repository)",
+        "create no worktree and write nothing into the rig checkout: no `switch`, no detach, no branch, no commit there",
+        'Read the item by `git -C "$GC_DIR" show <commit>:<path>` and `git -C "$GC_DIR" log -1 <commit>` only',
+        "a step that needs a checkout closes the item with `gc.outcome=fail` and `gc.failure_class=no-lane`",
+        "its close reason says in one line that the city must give this role a lane",
+        "`[[patches.agent]]` with `work_dir` and `pre_start` in `city.toml`",
+        "README, Worker workspaces",
+        "A formula step whose own text creates the item's worktree (`do-work/prepare-worktree` in the rig root) runs unchanged",
     ):
-        assert clause in flat, f"fallback paragraph lacks: {clause!r}"
-    # The only condition is the rig root; nothing in the Workspace section keys
-    # the fallback on the rig's rules.
-    for gone in ("When the rig's rules forbid", "rules forbid", "forbid working there"):
-        assert gone not in " ".join(workspace.split()), f"round-2 condition still present: {gone!r}"
-    # The fallback never fires where lanes are configured: no other paragraph
-    # of the Workspace section is conditional on the rig root.
-    assert sum(para.startswith("If ") for para in paragraphs(workspace)) == 1
+        assert clause in para, f"the no-lane paragraph lacks: {clause!r}"
+    assert positions[-1] < para.index("When any part fails") < para.index("`gc.failure_class=no-lane`")
 
-
-SCRIPT = REPO_ROOT / "gascity" / "assets" / "scripts" / "worker-worktree.sh"
-WORKFLOWS = REPO_ROOT / "gascity" / "assets" / "workflows"
-FORMULAS = REPO_ROOT / "gascity" / "formulas"
-
-
-def script_base_order() -> list[str]:
-    """The `--base` resolution order worker-worktree.sh implements, read from
-    the script itself so the prompt cannot drift from it: the remote refs it
-    probes, in source order, then its literal HEAD fallback."""
-    block = SCRIPT.read_text(encoding="utf-8").split('if [ -z "$BASE" ]; then', 1)[1].split("BASE_SHA=", 1)[0]
-    probes = re.findall(r"refs/remotes/\$REMOTE/(HEAD|main|master)", block)
-    assert 'BASE="HEAD"' in block, "the script no longer falls back to the rig's HEAD"
-    return [f"<remote>/{name}" for name in probes] + ["HEAD"]
-
-
-def test_workspace_fallback_resolves_its_base_and_needs_no_origin_remote() -> None:
-    """Gate r7 (round 8): the fallback required `origin/<default branch>`, so a
-    local-only rig, or one whose remote is not named origin, could never get a
-    workspace under a paragraph that now covers every unconfigured role. The
-    fallback RESOLVES the base in worker-worktree.sh's order and ends at the
-    rig checkout's HEAD; the order is read from the script, not retyped."""
-    fallback = [para for para in paragraphs(workspace_section()) if para.startswith(FALLBACK_OPENER)][0]
-    flat = " ".join(fallback.split())
-    order = script_base_order()
-    assert order == ["<remote>/HEAD", "<remote>/main", "<remote>/master", "HEAD"]
-    # Every candidate is named, in the script's order, after the sentence
-    # that says the base is resolved; the last one is the rig's own HEAD.
-    resolve_at = flat.index("Resolve the base of a new branch, never assume it")
-    positions = [flat.index(f"`{ref}`", resolve_at) for ref in order[:-1]]
-    positions.append(flat.index("else the rig checkout's current `HEAD`", resolve_at))
-    assert positions == sorted(positions), flat
+    # README, Worker workspaces: the same rule, and no fallback left half-removed.
+    readme = " ".join(README.read_text(encoding="utf-8").split())
+    section = readme[readme.index("## Worker workspaces") : readme.index("## Build Methodology Contract")]
+    assert "fallback" not in section.lower()
+    assert ".worktrees/<rig>/<bead>" not in section
     for clause in (
-        "in the order `worker-worktree.sh` uses",
-        "the remote's default branch when the rig has a remote",
-        "when the remote has another name, that name from `git -C <rig root> remote`",
-        "Pin the base to a commit in the rig",
-        "create the worktree from that commit",
-        "This fallback never fails for lack of a remote",
-        "never writes into the rig checkout",
-        "the checkout's HEAD and files do not move",
+        "A role the city gave no `work_dir` still starts in the rig root and has no lane",
+        "the role prompt then has it create no worktree and write nothing there",
+        "reads by `git show` and `git log` only",
+        "closes with `gc.outcome=fail` and `gc.failure_class=no-lane`, naming the fix, a lane for the role",
+        "No prompt-side path makes a workspace for an unconfigured role",
     ):
-        assert clause in flat, f"fallback paragraph lacks: {clause!r}"
-    # The sweep, pinned. The fragment and every role prompt name no `origin/`
-    # at all. A workflow step or formula may name `origin/` only where it
-    # RESOLVES the remote's HEAD itself (`git symbolic-ref
-    # refs/remotes/origin/HEAD`; upstream's do-work prepare-worktree step 5
-    # does, and fails closed without it by its own tested design, see
-    # tests/test_default_branch_resolution.py there) and never as the
-    # `origin/<default branch>` assumption this round removed.
-    prompts = [FRAGMENT, *sorted((REPO_ROOT / "gascity" / "roles" / "agents").glob("*/prompt.template.md"))]
-    steps = [*sorted(WORKFLOWS.rglob("*.md")), *sorted(FORMULAS.glob("*.toml"))]
-    assert len(prompts) > 1 and len(steps) > 20
-    for path in prompts:
-        text = path.read_text(encoding="utf-8")
-        for bare in ("origin/", "<default branch>"):
-            assert bare not in text, f"{path.relative_to(REPO_ROOT)} assumes a remote named origin: {bare!r}"
-    for path in steps:
-        text = path.read_text(encoding="utf-8")
-        assert "origin/<default branch>" not in text, f"{path.relative_to(REPO_ROOT)} assumes `origin/<default branch>`"
-        if "origin/" in text:
-            assert "symbolic-ref" in text and "refs/remotes/origin/HEAD" in text, (
-                f"{path.relative_to(REPO_ROOT)} names origin/ without resolving refs/remotes/origin/HEAD"
-            )
+        assert clause in section, f"README Worker workspaces lacks: {clause!r}"
 
 
 def test_worker_worktree_script_is_shipped_and_executable() -> None:


### PR DESCRIPTION
Stacked on #421 (worker workspaces: `worker-worktree.sh`, Workspace section). The first seven commits here are #421's; the last four are this change. Cut from upstream main + #421, not from a fork branch; once #421 merges this PR shows only its own commits.

## What

The role Workspace section (added in #421) still told a worker that started in a rig root whose `AGENTS` rules forbid working there to create its own `.worktrees/<rig>/<bead>`. In gc's model the unit of isolation is the agent: `work_dir` (gc creates it and starts the session there) plus `pre_start` (this pack's `worker-worktree.sh` makes it a worktree of the rig on the bead's branch). The worker never picks, creates, or hunts for a workspace, and the rig root stays a human checkout.

- `gascity/template-fragments/gc-role-worker.template.md` — the hunting paragraph is removed; the section says gc chose the directory, and keeps the restamp rule for older gc builds and the `work_dir` handoff stamp.
- `gascity/README.md` "Worker workspaces" — the standard wiring as a `[[patches.agent]]` block per role (`rig = "*"`, `work_dir`, `pre_start`), the documented surface for overriding an imported pack agent's fields; why the read-only roles get a lane too; why the pack does not set the keys by default (the script must be installed in the city's `.gc/scripts`, and a failing `pre_start` aborts the session start).
- `tests/test_gc_role_worker_fragment.py` — pins the new text; asserts no role prompt carries a hunting rule.

No change to `roles/agents/*/agent.toml`.

## Tests

`python3 -m pytest tests gascity/tests -q` on the fork branch: 320 passed, 8 skipped. On this branch: `tests/test_gc_role_worker_fragment.py gascity/tests/test_worker_worktree.py` — 44 passed.

Fork PR with the deployment evidence (citadel): aphexcx/gascity-packs-prs (link in the first comment).

## Round 2 — review round on the fork PR (two Major findings), same branch, still DRAFT

Two more commits, cherry-picked onto this branch from #421's head (never from a fork branch).

**M1 — the trimmed Workspace text was impossible for an un-configured installation.** The shipped roles carry no `work_dir`/`pre_start`, so a city that has not wired lanes starts a role in the rig root, and the text forbade working there while removing the escape path. Fix (`gc-role-worker.template.md` lines 67–72): the agent model stays the PRIMARY text (lines 57–65); ONE conditional paragraph follows it — if `$GC_DIR` is the rig root, the role has no `work_dir` in this city; when the rig's rules forbid working there, create the worktree under `<city>/.worktrees/<rig>/<bead>` from `origin/<default branch>` (check out the bead's branch if it already exists), work there, and mail the mayor that the role needs a lane (`work_dir` + `pre_start`, README "Worker workspaces"). It never fires where lanes are configured. Tests: the hunting phrases are allowed only inside the paragraph that begins "If `$GC_DIR` is the rig root" (paragraph-parsed, every role prompt); a new row pins exactly one such paragraph, after the primary text, conditional, naming the mail to the mayor.

**M2 — the `do-work` formula conflicted with the prohibition.** `assets/workflows/do-work/prepare-worktree.md` told the run operator to create a worktree and `implement.md` to switch into it. Both are now conditional on the workspace gc gave the session. `prepare-worktree.md` step 4 (lines 23–32): when `$GC_DIR` is already a git worktree of the rig on a branch (`git -C "$GC_DIR" rev-parse --is-inside-work-tree` prints `true` and `git -C "$GC_DIR" branch --show-current` prints a branch name, or the `pre_start` log says so, and `$GC_DIR` is not the rig root — the rig root is itself a checkout on a branch) the step creates nothing, sets `WORKTREE="$GC_DIR"` and continues at the persist step; otherwise the existing create step (remote-default-branch base) applies unchanged as step 5, persist as step 6. `implement.md` lines 9–13: when `work_dir` equals `$GC_DIR` there is nothing to switch into, work in `$GC_DIR`; otherwise the steps below apply unchanged. Test: `test_do_work_worktree_steps_are_no_ops_in_a_gc_lane` in `gascity/tests/test_formula_assets.py`, one row per file, exact clauses.

**Tests on this branch:** `tests/test_gc_role_worker_fragment.py gascity/tests/test_worker_worktree.py` green; `gascity/tests/test_formula_assets.py`: 112 passed, 18 failed — the same 18 fail on this branch's base (upstream main + #421; the `test_implementation_review_check_*` rows, unrelated to this change), the new row passes. On the fork branch the full suite is 322 passed, 8 skipped.

## Round 3 — review round on the fork PR (one Major finding), same branch, still DRAFT

One more commit, cherry-picked onto this branch from its own head `fcf4421` (never from a fork branch).

**The finding.** Round 2's `prepare-worktree.md` recorded the run operator's lane (`$GC_DIR`) as the source anchor's `work_dir`, so `implement` (a different agent) started in the operator's lane, which the operator's next `pre_start` can switch or move aside while implementation still uses it. A lane is per agent and is never handed to another agent; the item's **branch** is the handoff (every worktree of the rig shares its refs).

**Fix shape.**
- `assets/workflows/do-work/prepare-worktree.md` step 4 (lane case, lines 23–55; "Do NOT persist" at 51): creates nothing and hands no directory to anyone. Resolve the item's branch (`git -C "$GC_DIR" branch --show-current`; a detached lane gets `<source-anchor-id>` created from HEAD), record it with `gc bd update <source-anchor-id> --set-metadata gc.work_branch=<branch>`, detach the operator's lane (`git -C "$GC_DIR" switch --detach`) so the next role's lane can check the branch out, verify, and skip the `work_dir` persist step ("Do NOT persist `work_dir` in the lane case"). The rig-root steps (remote-default-branch base, persist) are unchanged.
- `assets/workflows/do-work/implement.md` (lines 10–26): when the source anchor has `gc.work_branch` and no `work_dir`, the worker's own `$GC_DIR` is the worktree, a lane its `pre_start` put on the item's branch; positive proof before editing, switch the OWN lane onto the recorded branch if `pre_start` named it differently, fail closed if git refuses or the branch is missing. Never enter another agent's lane; a persisted `work_dir` naming another agent's lane is invalid.
- `assets/workflows/do-work/close-source-anchor.md` (lines 14–19, after the existing one-element-list paragraph, which now opens with "Unless the lane case below applies"): the lane case verifies the commit by branch from the operator's own lane (`git -C "$GC_DIR" log -1 <gc.work_branch>`).
- `assets/scripts/worker-worktree.sh`: unchanged; its reuse path already checks out an existing local branch that no worktree holds. New row `test_existing_local_branch_left_by_a_detached_lane_is_checked_out` pins the handoff.
- `gascity/tests/test_formula_assets.py`: `test_do_work_lane_case_hands_over_the_branch_never_the_directory` replaces the round-2 row (positive clauses for all three assets; step 4 carries neither `work_dir=` nor `WORKTREE="$GC_DIR"`; the round-2 "When `work_dir` equals `$GC_DIR`" clause is gone).

**Tests on this branch:** `tests/test_gc_role_worker_fragment.py gascity/tests/test_worker_worktree.py` 46 passed; `gascity/tests/test_formula_assets.py` 112 passed, 18 failed — the identical 18 `test_implementation_review_check_*` rows fail on this branch's base `fcf4421` (failure sets diffed: identical), the new row passes (subtests 5989 → 6003). `git diff --check` clean. On the fork branch the full suite is 323 passed, 8 skipped, 9412 subtests passed.

## Round 4 — review round on the fork PR (two Major findings), same branch, still DRAFT

One more commit, cherry-picked onto this branch from its own head `9ffe62d` (never from a fork branch); it applied clean.

**M1 — the round-3 lane test was too weak; a subdirectory of the human checkout could be detached.** `rev-parse --is-inside-work-tree` and `branch --show-current` both succeed from any subdirectory of the rig checkout, and such a `$GC_DIR` is also "not the rig root", so a `work_dir` configured inside the human checkout would have reached `switch --detach` and detached the human checkout's HEAD. Fix:
- `assets/workflows/do-work/prepare-worktree.md` step 4 (lines 23–78): the probes only say this MAY be the lane case (line 28); a three-part boundary test (lines 36–55) runs BEFORE the branch is resolved, recorded, or the lane detached (line 66), all paths resolved through symlinks: (1) `git -C "$GC_DIR" rev-parse --show-toplevel` equals `$GC_DIR` itself (a subdirectory of any checkout fails); (2) that top-level is neither the rig root (`gc.work_dir` on the workflow root bead) nor inside it (prefix + separator); (3) `git -C "$GC_DIR" rev-parse --git-common-dir` resolves to the rig root's `.git` (a worktree of another repository fails). Any failure is NOT the lane case: record nothing, `switch` nothing, detach nothing, continue with step 5 exactly as before (upstream's remote-default-branch create step, then persist). The step says why: a subdirectory of a human checkout must never be detached.
- `assets/workflows/do-work/implement.md` lane paragraph (lines 10–35): the same test (lines 14–23) before editing and before any `switch`; on failure, fail the step before editing and never `switch` there (switching a subdirectory of the rig checkout would switch the human checkout's branch). The `rev-parse --verify` / `show-current` / `switch "<gc.work_branch>"` sequence follows unchanged.
- `assets/workflows/do-work/close-source-anchor.md`: unchanged (read-only lane clause; upstream's one-element-list paragraph stays as round 3 left it).

**M2 — a default installation had no permitted workspace.** The pack ships every role without `work_dir`/`pre_start`, so an un-configured city starts roles in the rig root, forbids working there, and the round-2 fallback fired only "when the rig's rules forbid working there". Fix: `gc-role-worker.template.md` lines 56–60, the fallback is conditional ONLY on `$GC_DIR` being the rig root: create `<city>/.worktrees/<rig>/<bead>` from `origin/<default branch>` (check out the bead's branch if it exists), work there, mail the mayor that this role needs a lane. The rules condition is gone; the primary text (gc chose the workspace, never the rig root, never hunt) is unchanged. `gascity/README.md` lines 218–222: the parenthetical now states the fallback instead of saying the rule is gone.

**Tests.** `test_do_work_lane_case_hands_over_the_branch_never_the_directory` (`gascity/tests/test_formula_assets.py` line 2203) gains the boundary-test clauses and ordering asserts (lines 2295–2315: each probe before the record and the detach in step 4, before the switch in implement); `test_workspace_fallback_covers_every_unconfigured_role` (`tests/test_gc_role_worker_fragment.py` line 96) replaces the round-2 row (rig root is the only condition; "rules forbid" gone; path and mail-the-mayor kept). **Tests on this branch:** the three files above: 20 failed, 156 passed, 6026 subtests; on this branch's base `9ffe62d`, run today: 20 failed, 156 passed, 6003 subtests; failure SETS diffed: identical. The set = the 18 pre-existing `test_implementation_review_check_*` rows + 2 `test_city_claim_command_*` rows that time out (2 s) on base and head alike (also in isolation); the same two rows pass on the fork branch and this commit touches nothing under `gascity/commands`, so they belong to this branch's `claim/run.sh`, not to this round (round 3 reported 18; the two claim rows are drift on this branch since then). On the fork branch the full suite is 323 passed, 8 skipped, 9435 subtests passed. `git diff --check` clean.

## Round 5 — codex gate r4 (fork PR aphexcx/gascity-packs-prs#32) BLOCK (2 Major) fixed; commit 86ec364 cherry-picked onto this branch's own head 26c4f84, still DRAFT

**M1 — every reader of the source anchor's `work_dir` carries the lane clause.** Rounds 3 and 4 fixed the readers each gate named; gate r4 found the next two (`implement.md` line 45 still required the directory; `setup-build-basic-review` wrote it into the review context). Now one clause in every reader: when the source anchor has no `work_dir` and records `gc.work_branch`, the workspace is the step's OWN lane `$GC_DIR` (round-4 boundary test) put on the recorded branch with `git -C "$GC_DIR" switch --no-overwrite-ignore "<gc.work_branch>"` to work, or the branch's commit read from the own lane (`git log -1 <commit>`, `git show <commit>:<path>`) to inspect; never another agent's lane; a `work_dir` naming an agent lane (`.worktrees/<rig>/lane-*`) is invalid, fail closed. Readers (lines on this branch): `do-work/prepare-worktree.md` 74–83 (the writer names the contract), `do-work/implement.md` 10–41 + 43–54 (line 45 now says the lane case is the exception), `do-work/close-source-anchor.md` 14–21 (upstream's one-element-list paragraph kept as round 3 left it), `do-work-item/implement-item.md` 7–13 + 15–28 and `implementation-item-base/implement-item.md` 8–27 (now name `work_dir` instead of "the authoritative worktree"), `implementation-base/implement.md` 7–26, `build-basic-review/{target}.setup-build-basic-review.md` 30–40 (records BRANCH + COMMIT id in place of a directory), `{target}.acceptance-review.md` 28–39, `{target}.simplicity-review.md` 21–28, `{target}.test-evidence-review.md` 23–30, `{target}.apply-review-findings.md` 31–47 (the fix lane applies the implement lane paragraph). The two `gc.work_dir`-only steps (`build-base/summarize-implementation.md`, `implement/summarize.md`) read the launcher root for the validator and are unchanged.

On this branch upstream already has an `## Implementation Worktrees` contract in `build-basic-review/` (setup resolves `metadata.work_dir` per source anchor; acceptance and apply read that section). Those paragraphs are kept word for word; the round-5 clause sits beside them: setup's "If no implementation worktree can be resolved … `gc.outcome=fail`" is qualified by "and the lane case in the next paragraph does not apply", and the section's field list gains "or, in the lane case, the recorded branch (`gc.work_branch`) and commit id in place of a path"; acceptance's and apply's clauses name the section.

**M2 — every switch onto `<gc.work_branch>` is `git switch --no-overwrite-ignore` and the step fails on the refusal** (an ignored file in the lane colliding with a tracked path on the branch): never `--force`, never a stash, never removing the file; `worker-worktree.sh` `switch_worktree` already protects the same case.

**Tests** (`gascity/tests/test_formula_assets.py`): line 2349 `test_every_work_dir_reader_carries_the_lane_clause` (grep-driven: every `work_dir` hit not preceded by `gc.` must carry `gc.work_branch` + "no `work_dir`" + never-enter-another-lane + own lane; eleven readers as the floor), line 2377 `test_every_lane_switch_refuses_to_overwrite_ignored_files` (every switch span with `<gc.work_branch>` carries the flag and no `--force`; probes before the switch in the editing steps), line 2431 `test_review_setup_records_branch_and_commit_when_work_dir_is_absent`; the round-3/4 row updated to the flagged switch. On this branch `test_formula_assets.py` + `test_worker_worktree.py` + `tests/test_gc_role_worker_fragment.py`: 18 failed, 161 passed, 6086 subtests; base 26c4f84: 18 failed, 158 passed, 6026 subtests; failure sets identical (the pre-existing `test_implementation_review_check_*` rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round 6 — codex gate r5 (fork PR aphexcx/gascity-packs-prs#32) BLOCK (1 Major) fixed; commit 52f737e cherry-picked onto this branch's own head 86ec364, still DRAFT

**The finding.** Round 5 had every review lane put its OWN lane on `<gc.work_branch>` to run proof commands, but git allows one worktree per branch: the implementation lane still held the branch after `implement`, so the reviewer's switch failed ("already checked out at …"), three parallel reviewers would have contended for it, and the fix lane was blocked the same way.

**The fix: one lifecycle, stated once in `do-work/prepare-worktree.md`'s contract paragraph (lines 79–103 here) and applied by every step.** A lane HOLDS the item's branch only while it is writing to it and RELEASES it when it hands off; every reader INSPECTS the recorded commit detached, never on the branch. (1) Writers release on handoff: `do-work/implement.md` 68–83, `do-work-item/implement-item.md` 30–41, `implementation-base/implement.md` 24–36, `implementation-item-base/implement-item.md` 29–40 and `build-basic-review/{target}.apply-review-findings.md` 49–67 run `git -C "$GC_DIR" switch --detach` after the final commit and before closing with `gc.outcome=pass`, verify `branch --show-current` prints nothing, and name the commit id in the close reason. (2) Readers never take the branch: `{target}.acceptance-review.md` 33–43, `{target}.simplicity-review.md` 26–32 and `{target}.test-evidence-review.md` 28–34 run proof commands DETACHED at the recorded commit in their own lane (`git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>`, resolving `rev-parse "<gc.work_branch>"` first when the context carries only the branch), fail closed when git refuses, and never switch onto the branch. (3) The fix lane takes the branch (free, the writer released it), commits, releases; if another worktree still holds it (git: "already checked out at <path>", or "already used by worktree at <path>" in newer git; `git worktree list` names the holder) the step fails closed with the holder's path and mails the mayor, never entering that lane, never `--force`, never removing its checkout. (4) Recovery: the operator releases a crashed writer's branch with `git -C <holder lane> switch --detach`; no step ever releases another agent's lane. (5) `close-source-anchor.md` unchanged; the README's Worker workspaces section (293–301) gains the lifecycle.

Upstream's `## Implementation Worktrees` paragraphs in `build-basic-review/` are kept word for word (the cherry-pick applied without conflicts; the diff removes only round 5's reader clause lines).

**Tests.** NEW `gascity/tests/test_lane_lifecycle.py` (real git, temp dir, worktrees as lanes, no network): operator lane creates the item branch and detaches; implement lane takes, commits, releases; TWO reviewer lanes detach at the recorded commit at the same time and `git show <commit>:<path>`; fix lane takes, commits, releases; `git log -1 <branch>` is the fix commit; no "already checked out"/"already used by worktree"; the operator lane stays detached; the rig root never changes. Second scenario: the implement lane does not release, the fix lane's switch fails naming the holder, nothing is forced, releasing from the holder's lane unblocks it. Third: the reader's detach refuses to overwrite an ignored file. `gascity/tests/test_formula_assets.py` line 2514 `test_lane_handoff_lifecycle_holds_while_writing_and_releases_on_handoff` pins the sentences (writers' release ordered after the take; readers' detach and NO switch onto the branch; the fix lane's boundary < take < holder failure < release; README); round-5 rows at 2377 and 2434 updated (six switching steps, readers have none; acceptance's clause is the detach). On this branch `test_formula_assets.py` + `test_worker_worktree.py` + `test_lane_lifecycle.py` + `tests/test_gc_role_worker_fragment.py`: 18 failed, 165 passed, 6121 subtests; base 86ec364: 18 failed, 161 passed, 6086 subtests; failure sets identical (the pre-existing `test_implementation_review_check_*` rows).

## Round 7 — codex gate r6 (fork PR aphexcx/gascity-packs-prs#32) BLOCK (2 Major) fixed; commit 80efe8e cherry-picked onto this branch's own head 52f737e, still DRAFT

Ruling: `assets/ops/codex-gates/gp-0mvp-gate-r6.out` (citadel), also a comment on the fork PR. Rounds 1 to 6 untouched (no squash); the city half stands and is not touched by this round.

**M1 — the review context is stale after a fix (right).** `setup-build-basic-review` runs ONCE, outside the review loop (`build-basic-review.formula.toml`: the setup is a sibling of the loop template, the loop's children repeat up to six times), and the three review lanes inspect the commit it recorded; `apply-review-findings` line 46 named its fix commit only in its close reason. So every later attempt re-reviewed the ORIGINAL code and repeated resolved findings until the attempts ran out. Fix: the setup also records `gc.build.review_commit=<commit>` on the workflow root on its first run; the fix lane, after its fix commit and BEFORE releasing the branch, rewrites the commit id (and the changed-file list) in the review context file at `gc.build.code_review_context_path` and records the new commit on the root with the same key; the three review lanes read the key first and fall back to the context file's commit only when the key is absent. The retry sequence is stated in the fix lane: fix, commit, refresh the context, release the branch; then the loop re-runs the reviewers on the new commit. "Never leave the old commit in the context after a fix." The refresh applies in the `work_dir` case too; only the release is the lane case.

**M2 — reviewers detached without the boundary test (right).** `acceptance-review` line 21 (and simplicity, test-evidence) ran `git -C "$GC_DIR" switch --detach --no-overwrite-ignore <commit>` with no boundary test; a reviewer role with no configured `work_dir` starts in the RIG ROOT (the human checkout; the Workspace fallback creates a worktree only for writing roles), so that detach would have moved the human checkout's HEAD. Fix: every reader proves the lane FIRST, before any `switch` or detach, with the same three-part test `do-work/prepare-worktree` step 4 applies (resolved top-level equals `$GC_DIR`; not the rig root nor inside it; `--git-common-dir` is the rig root's `.git`). When any part fails the lane switches and detaches NOTHING, inspects by `git -C "$GC_DIR" show <commit>:<path>` and `git -C "$GC_DIR" log -1 <commit>` only (safe from any checkout of the rig's repository), and if a proof command needs a checkout at the commit it closes with `gc.outcome=fail`, `gc.failure_class=no-lane` and the reason "no lane for this role", naming the fix (a `work_dir` for the role, README Worker workspaces). `apply-review-findings` says its release is inside the guarded lane case (after the boundary test passed and the switch succeeded; a `$GC_DIR` that failed the test was never switched and detaches nothing; the `work_dir` worktree is already detached, nothing to release). prepare-worktree's contract paragraph gains both rules (readers apply the same boundary test; a writer that commits after a recorded commit refreshes it). README Worker workspaces gains the two sentences.

**The sweep (DO-NOT 218's rule).** grep of the whole `assets/workflows` tree for `switch`, `--detach`, `checkout`: every COMMAND span that switches or detaches sits in the contract (`do-work/prepare-worktree.md`), the five writers or the three readers, and in each file it comes after the three-part boundary test; the only other detach is `git worktree add "$WORKTREE" --detach HEAD` in prepare-worktree step 5 (a creation, not a switch of an existing checkout, on the rig-root path after step 4's test failed). No `git checkout` anywhere. Recorded commit ids/branches: `gc.work_branch` on the source anchor (a branch name, read by name by `close-source-anchor` and the review setup, so a later commit on it is seen); the review setup's commit id (M1, now refreshed by the only writer that commits after it); the writers' "commit id in the close reason" (informational, no later step reads it). Nothing else found; nothing else changed.

Changed lines (this branch 80efe8e; fork 0613cc1 line numbers differ where noted in the fork PR body):

| File | Lines | What changed |
|---|---|---|
| `build-basic-review/{target}.setup-build-basic-review.md` | 6–13, 41 (6–13, 74) | records `gc.build.review_commit` on first run; runs once; close condition |
| `build-basic-review/{target}.apply-review-findings.md` | 46–64, 68–74 (62–80, 84–90) | the refresh paragraph (context file + root key, retry sequence) between the holder failure and the release; the release is inside the guarded lane case |
| `build-basic-review/{target}.acceptance-review.md` | 17–44 (30–57) | read the current commit (key first, context fallback); boundary test before the detach; rig-root case, show/log only, "no lane for this role" |
| `build-basic-review/{target}.simplicity-review.md` | 15–33 (25–43) | same, short form |
| `build-basic-review/{target}.test-evidence-review.md` | 16–34 (27–45) | same, short form |
| `do-work/prepare-worktree.md` | 91–102 (94–105) | contract paragraph: readers apply the boundary test; a writer after a recorded commit refreshes it |
| `README.md` Worker workspaces | 266–275 (300–309) | two sentences: every lane proves it is a lane before switching/detaching; the fix lane refreshes the recorded commit |

**Tests.**
- `gascity/tests/test_formula_assets.py` line 2426 (2648) `test_review_context_is_refreshed_after_a_fix_and_readers_read_the_current_commit`: the setup's key + "runs ONCE"; the fix lane's refresh ordered commit < refresh < key < release, the retry sequence, "Never leave the old commit"; every reader "Read the CURRENT commit first" + key + fallback + ordered before its detach; the contract bullet; grep-driven: every workflow step that names the review context and commits (`commit the fix on` / `` `git commit` ``) carries the refresh (exactly the fix lane), and the set of files naming `gc.build.review_commit` is exactly {contract, setup, fix lane, three readers}; README. Line 2537 (2759) `test_every_switch_or_detach_in_the_workflows_tree_is_preceded_by_the_boundary_test`: grep-driven over every `*.md` in the tree: every command span (contains `git`) with `switch`/`--detach`/`checkout` comes after `rev-parse --show-toplevel` and `rev-parse --git-common-dir` in its file, the file has a "when any part fails" branch, no `--force`, no `git checkout`; the set of switching files is exactly {contract, 5 writers, 3 readers}; every reader: boundary before detach, "prove the lane FIRST, before any `switch` or detach", RIG ROOT named, "switches and detaches nothing", show/log only, `gc.failure_class=no-lane`, "no lane for this role", the README fix, "Only when all three parts hold:" before the detach, still no release and no branch switch; the fix lane's release after the probes and "inside the guarded lane case"; contract + README clauses. Both rows were proven to FAIL on a mutated text (the `--git-common-dir` probe removed from the simplicity lane; the `gc.build.review_commit=<sha>` refresh removed from the fix lane) and pass on the real text. The lifecycle row's list of real-git scenarios grew by two.
- `gascity/tests/test_lane_lifecycle.py` (real git, temp dir, no network). Line 364 `test_fix_lane_refreshes_the_recorded_commit_so_the_next_attempt_reviews_the_fix`: the setup lane records commit A (context file with commit + changed files, and the root key modelled as a dict); attempt 1's reader reads A and detaches at A; the fix lane takes the branch, commits B, REFRESHES the context and the key while it still holds the branch, then releases; A is gone from the context; attempt 2's reader reads B from the key, and B from the context when the key is absent, detaches at B and sees the fix; rig root untouched, no contention. Line 438 `test_reviewer_in_the_rig_root_never_detaches_the_human_checkout`: the three-part boundary test implemented with the text's git commands (line 185): a real lane passes (True, True, True); the rig root fails part 2; a subdirectory of the rig root fails part 1; a worktree of another repository fails part 3; the reviewer whose `$GC_DIR` is the rig root runs no switch/detach, reads `git show <commit>:<path>` and `git log -1 <commit>` there, and the rig root's branch/HEAD/status are unchanged; the lane reviewer still detaches fine; last, the withheld round-6 command run in the rig root is shown to detach the human checkout and move its HEAD (what the guard prevents).
- Full suite, `env -u GC_TEMPLATE uv run --with pytest --with PyYAML --with jsonschema python -m pytest tests gascity/tests -q` in the lane worktree at 0613cc1: **334 passed, 8 skipped, 9598 subtests passed** (round 6: 330 / 8 / 9530; four tests added). `git diff --check` clean.

**Judgment calls, flagged:** (1) The root key is `gc.build.review_commit` (the bead's example name); the reader order is key first, context file second, because the key is one `gc bd show` away and the context file's format is the setup's. (2) A reader that cannot detach and needs a proof command closes with `gc.outcome=fail` + `gc.failure_class=no-lane` (the role prompt's failure contract) rather than `gc.outcome=pass` + an `iterate` verdict: an `iterate` would send the fix lane after a defect that is a deployment gap, and the loop's check then fails closed on the missing verdict. (3) The fix lane's refresh is placed between the holder-failure paragraph and the release paragraph, so the round-6 ordering row (boundary < take < holder < release) is unchanged and the new row adds commit < refresh < release. (4) The rig-root scenario ends by running the withheld command against the rig root to show the harm (HEAD moves off `main`); the rig is a temp dir and the assertion is the last one in the test. (5) The lifecycle test models the workflow-root metadata as a dict and the context file as a real file: the bead store is not part of the test, git is. (6) The sweep's grep is over command spans (backticked, containing `git`); prose mentions like "before any `switch`" are not commands and sit before the probes by design.

**Cut:** the same commit cherry-picked onto this branch's own head `52f737e` (never from the fork head): head `80efe8e`, no conflicts; upstream's `## Implementation Worktrees` sentences kept word for word. On this branch, `test_formula_assets.py` + `test_worker_worktree.py` + `test_lane_lifecycle.py` + `tests/test_gc_role_worker_fragment.py`: 18 failed, 169 passed, 6189 subtests; base `52f737e`: 18 failed, 165 passed, 6121 subtests; failure row sets diffed: identical (the 18 pre-existing `test_implementation_review_check_*` rows).

## Round 8 — codex gate r7 BLOCK (1 Major) fixed; commits 50acfa3 + 0b2157a on the same branch, still DRAFT

Ruling: `assets/ops/codex-gates/gp-0mvp-gate-r7.out` (citadel), also a comment on this PR. Rounds 1 to 7 untouched (no squash); the city half stands and is not touched by this round.

**M1 — the Workspace fallback required `origin/<default branch>` (right).** `gc-role-worker.template.md` line 67: since round 4 the fallback covers every role the city gave no `work_dir`, and it told the worker to create its worktree from `origin/<default branch>`. A local-only rig, or one whose remote is not named origin, could never obtain a workspace under that text, so a bead that could previously run in the permitted rig checkout was blocked. `worker-worktree.sh` (the pack's `pre_start`, the city half) already resolves an available base and falls back to the rig's HEAD. Fix: the fallback paragraph now RESOLVES the base, never assumes it, in the order the script uses (quoted from its `--base` default, lines 248–259): the remote's default branch when the rig has a remote (`<remote>/HEAD`, else `<remote>/main`, else `<remote>/master`, `<remote>` being `origin` or, when the remote has another name, that name from `git -C <rig root> remote`; fetched first), else the rig checkout's current `HEAD`; pinned to a commit in the rig (`rev-parse --verify '<base>^{commit}'`); the worktree created from that commit with `git -C <rig root> worktree add -b <bead> <path> <commit>`. "This fallback never fails for lack of a remote, and it never writes into the rig checkout: it fetches, reads refs, and registers the worktree from there; the checkout's HEAD and files do not move." The paragraph is still the one conditional fallback (opener unchanged), so the round-4 rows hold.

**The sweep (DO-NOT 218's rule).** grep of the fragment, every role prompt, every `assets/workflows/**/*.md` step and every formula for `origin/` and `<default branch>`: on this branch the fragment was the only consumer; `do-work/prepare-worktree` step 5 (the rig-root path) already creates its per-item worktree with `--detach HEAD`, so step 2 of the bead touched no formula here. README Worker workspaces: the fallback sentence names the resolution (a local-only rig or a remote not named origin still gets a workspace; the rig's HEAD never moves), and the script's description no longer says `origin/HEAD` only (it names the four-step order, `--remote`, `--base`). `README.md` line 495 (`origin/main` in an issue-priority guideline) is not a workspace consumer and is unchanged.

Changed lines (fork 0b2157a; twin 4812af0 in parentheses):

| File | Lines | What changed |
|---|---|---|
| `template-fragments/gc-role-worker.template.md` | 67–81 (56–70) | the fallback paragraph: resolution order, pin, create, the two closing guarantees |
| `README.md` Worker workspaces | 184–191, 246–251 (218–225, 280–285) | fallback sentence; the script's base description |
| `tests/test_gc_role_worker_fragment.py` | 114–115, 129–193 | round-4 row's clauses follow the new text; `script_base_order()` + the new row |
| `gascity/tests/test_lane_lifecycle.py` | 29–36, 222–256, 549–595 | docstring rule 8; `fallback_resolves_base` / `fallback_creates_workspace`; the new scenario |
| `gascity/tests/test_formula_assets.py` | 2411 (2633) | the lifecycle enumeration names the new scenario |

**Tests.**
- `tests/test_gc_role_worker_fragment.py` line 144 `test_workspace_fallback_resolves_its_base_and_needs_no_origin_remote`: the resolution order is READ from `worker-worktree.sh`'s `--base` block (`script_base_order()`, line 134: the `refs/remotes/$REMOTE/{HEAD,main,master}` probes in source order, then its literal `BASE="HEAD"`), asserted equal to `<remote>/HEAD, <remote>/main, <remote>/master, HEAD`; every candidate is named in the paragraph in that order after "Resolve the base of a new branch, never assume it", the last being "else the rig checkout's current `HEAD`"; eight clauses (the script's order, a remote with another name, pin, create from the commit, "never fails for lack of a remote", "never writes into the rig checkout", HEAD and files do not move); the grep sweep: no `origin/` or `<default branch>` in the fragment or any role prompt; no `origin/<default branch>` in any workflow step or formula; a step may name `origin/` only when it also resolves `refs/remotes/origin/HEAD` by `symbolic-ref` (second commit, see the twin note). Proven to FAIL on four mutations: the round-7 text restored (`assumes a remote named origin: 'origin/'`), the candidates reordered (`[470, 448, 492, 638] == [448, 470, 492, 638]`), `origin/<default branch>` injected into a workflow step, a bare `origin/main` injected with no resolution; passes on the real text.
- `gascity/tests/test_lane_lifecycle.py` line 550 `test_role_without_a_lane_in_a_rig_without_a_remote_gets_a_workspace_from_the_rig_head` (real git, temp dir, no network): the rig has NO remote (`git remote` empty; `origin/HEAD`, `origin/main`, `origin/master` do not resolve); `$GC_DIR` is the rig root and the three-part boundary test fails part 2, so this is the fallback; the documented resolution (`fallback_resolves_base`, line 225, the paragraph's commands in the paragraph's order) returns `("HEAD", <main sha>)`; `<city>/.worktrees/<rig>/gp-nolane1` is created from that commit on the bead's branch, passes the boundary test `(True, True, True)`, and a commit made there lands on the bead's branch while `main` and the rig checkout's branch/HEAD/status are unchanged; no contention. Then a bare mirror is added as a remote named `upstream` (not origin) with its HEAD set, and the same order returns `("upstream/main", <main sha>)`: the paragraph's first candidate is real, not only its last. The enumeration row in `test_formula_assets` names the scenario (proven to fail when the scenario is renamed).
- Full suite, `env -u GC_TEMPLATE uv run --with pytest --with PyYAML --with jsonschema python -m pytest tests gascity/tests -q` in the lane worktree at 0b2157a: **335 passed, 8 skipped, 9599 subtests passed** (round 7: 334 / 8 / 9598; one test added). `git diff --check` clean.

**Judgment calls, flagged:** (1) The paragraph tells the worker to fetch the remote before resolving (the script does); a fetch writes refs under the rig's `.git`, not its working tree, which is what "never writes into the rig checkout" promises (HEAD and files do not move; the lifecycle scenario asserts branch, HEAD and status). (2) The remote is `origin` when one is named so, else the rig's other remote as `git remote` prints it; the script itself takes `--remote` and defaults to `origin`, so a rig whose only remote has another name reaches the script's HEAD fallback unless the city passes `--remote` — the paragraph goes one step further than the script for the prompt case, which is what the finding asked for (a differently named remote gets a workspace). (3) The no-remote scenario ends with a positive proof of the first candidate (a remote named `upstream`), in the same test rather than a second one, so the bead's "ONE real-git scenario" stays one. (4) **Twin only:** upstream's `do-work/prepare-worktree` step 5 (the rig-root path) resolves `refs/remotes/origin/HEAD` with `symbolic-ref` and FAILS CLOSED without it, "do not fall back to local HEAD", pinned by upstream's `tests/test_default_branch_resolution.py`; the first cut of the sweep row flagged it on the twin (`19 failed` vs base `18`). That step resolves the remote HEAD rather than assuming `origin/<default branch>`, and reversing upstream's tested contract is not this mirror PR's call, so the second commit narrows the sweep to "a step may name `origin/` only where it resolves `refs/remotes/origin/HEAD` itself" (still bans the assumption everywhere, still bans any `origin/` in the worker fragment and role prompts). Whether upstream's step 5 should also fall back to the rig's HEAD for a local-only rig is a question for upstream, raised here, not decided here.

**Upstream twin:** #422 re-cut with the two commits cherry-picked onto its own head `80efe8e` (never from this PR's head): heads `f11690e` then `4812af0`, no conflicts; upstream's `## Implementation Worktrees` sentences in the acceptance, apply and test-evidence lanes kept word for word. On the twin, `test_formula_assets.py` + `test_worker_worktree.py` + `test_lane_lifecycle.py` + `tests/test_gc_role_worker_fragment.py`: 18 failed, 170 passed, 6190 subtests; base `80efe8e`: 18 failed, 169 passed, 6189 subtests; failure ROW sets (FAILED + SUBFAIL, sorted) diffed: identical (the 18 pre-existing `test_implementation_review_check_*` rows).

## Round 9 — Afik 9/9 22:28 CT "drop the fallback"; codex gate r8 BLOCK (1 Major, 1 Minor) fixed; commit 2a6d66b on the same branch, still DRAFT

Ruling: `assets/ops/codex-gates/gp-0mvp-gate-r8.out` (citadel), also a comment on this PR. Afik's design word (C0ASAPRETDK, 9/9 22:28 CT 1789010886.680819, verbatim): "yeah i agree, drop the fallback if we don't use it", answering the mayor's read that rounds 2, 3, 4, 7 and 8 all patched the lane-less fallback, a path no citadel dispatch takes since the city half went live (9/9 22:58Z: every gc role has a `[[patches.agent]]` lane). Rounds 1 to 8 untouched (no squash); the city half stands and is not touched by this round.

**Afik's word: the lane-less workspace fallback is DROPPED.** `gc-role-worker.template.md` lines 67–81: the paragraph that had a role the city gave no `work_dir` create `<city>/.worktrees/<rig>/<bead>` (round 8's resolution order, pin and create commands included) is gone, and with it the README's fallback sentences and every test that pinned it. In its place ONE fail-closed paragraph (lines 67–82): a session outside a gc-made lane has no lane. The three-part boundary test is now stated in the fragment itself (the resolved top-level of `$GC_DIR` is `$GC_DIR` itself; neither the rig root, `$GC_RIG_ROOT`, nor inside it; the git common dir is the rig root's `.git`); when any part fails the session creates no worktree and writes nothing into the rig checkout (no `switch`, detach, branch or commit there), reads the item by `git show <commit>:<path>` / `git log -1 <commit>` only, and a step that needs a checkout closes `gc.outcome=fail`, `gc.failure_class=no-lane`, its close reason saying in one line that the city must give the role a lane (`[[patches.agent]]` `work_dir` + `pre_start` in `city.toml`). A formula step whose own text creates the item's worktree (`do-work/prepare-worktree` step 5, the rig-root path) runs unchanged. The fragment now carries NO worktree-creating instruction: no `git worktree add` verb anywhere in it.

**M1 — the review commit was one workflow-wide SHA (right).** `acceptance-review.md` line 18: `gc.build.review_commit` on the workflow root, while separate drains produce several source anchors on independent branches; readers preferring it inspected one item's revision for all of them, and a fix on one item overwrote the revision for the others. Fix: the review commit is recorded PER SOURCE ANCHOR, as `gc.review_commit` on the source anchor bead plus the anchor's own record in the context file (the context carries one record per source anchor). Shape chosen and why: the source anchor is already the per-item record (`gc.work_branch` and `work_dir` live there), so the fix lane's write touches only the bead it committed on (no read-modify-write of a shared root record, no key name templated on an anchor id); the readers already resolve the anchor id from the context, and `gc bd show <source-anchor-id> --json` is one call; the drain-unit rule already exists (stamp the original drain member, never the synthetic convoy). The setup writes the key on every anchor the context names; `apply-review-findings` rewrites only the record and key of the anchor it committed on ("Touch no other source anchor's record or key"); the three readers read their anchor's key first and that anchor's record second, never a workflow-wide key; the old key is removed from every step, the README and the fragment (no dual path: `gc.build.review_commit` no longer appears in the assets). The do-work contract paragraph (`prepare-worktree` step 4) states the per-item refresh.

**M2 (minor) — the uncollected test (right).** `test_lane_lifecycle.py` line 550: the round-8 scenario sat after `unittest.main()` in the `__main__` block. It goes with the fallback; every scenario is inside `LaneLifecycleTests`, and `--collect-only` collects 7 (the five surviving scenarios plus the two below).

**The sweep (DO-NOT 218's rule).** grep of the tree for `fallback`, `no-lane`, `worktree add`, `.worktrees/<rig>/<bead>`, `<remote>/HEAD`, `gc.build.review_commit`: the fragment (the paragraph), README Worker workspaces (the fallback sentences at 184–191; the lifecycle sentence at 279–282), `do-work/prepare-worktree.md` (the contract paragraph), the five `build-basic-review` steps, `tests/test_gc_role_worker_fragment.py`, `gascity/tests/test_formula_assets.py`, `gascity/tests/test_lane_lifecycle.py`. Left as they are, on purpose: "Default fallback behavior must still enforce the worktree contract" in the four implement variants (the methodology base's default step behaviour, not the workspace fallback); `build-base/prepare.md`'s "this fallback exists so inherited steps..." (formula inheritance); `worker-worktree.sh`'s "detached fallback" (the script's own detached mode); `prepare-worktree` step 5 and the readers' round-7 "starts in the RIG ROOT, the human checkout ... show/log only ... no-lane" paragraphs, which ARE the fail-closed behaviour the new paragraph names.

Changed lines (fork 2a6d66b; twin 111f5f8 in parentheses):

| File | Lines | What changed |
|---|---|---|
| `template-fragments/gc-role-worker.template.md` | 67–82 (56–71) | the fallback paragraph replaced by the no-lane paragraph |
| `README.md` Worker workspaces | 185–190, 277–283 (219–224, 311–317) | no fallback; the per-anchor refresh |
| `do-work/prepare-worktree.md` | 99–104 (102–107) | the contract paragraph: the refresh is per source anchor |
| `build-basic-review/{target}.setup-build-basic-review.md` | 6–20, 23–25, 49–50 (6–20, 23–25, 82–83) | one record per anchor; `gc.review_commit` on each anchor; no root key |
| `build-basic-review/{target}.apply-review-findings.md` | 52–61, 65–66 (68–77, 81–82) | refresh the anchor's record and key only |
| `build-basic-review/{target}.acceptance-review.md` | 15–27 (28–40) | read the anchor's key first, its record second |
| `build-basic-review/{target}.test-evidence-review.md` | 12–22 (23–33) | same |
| `build-basic-review/{target}.simplicity-review.md` | 11–21 (21–31) | same |
| `tests/test_gc_role_worker_fragment.py` | 62–69, 82–98, 100–176 | the two fallback rows and `script_base_order()` removed; no exempt paragraph; the new row |
| `gascity/tests/test_formula_assets.py` | 2224, 2411–2412, 2426–2583 (2446, 2633–2634, 2648–2805) | the round-5 clause follows the text; the enumeration; the per-anchor row |
| `gascity/tests/test_lane_lifecycle.py` | 20–41, 131–297, 454–512, 594–724 | per-anchor and no-lane helpers; the two scenarios; the fallback helpers and the uncollected scenario removed |

**Tests.**
- `tests/test_gc_role_worker_fragment.py` line 100 `test_session_outside_a_lane_creates_no_worktree_and_fails_closed_no_lane`: no `worktree add` verb and no trace of the fallback anywhere in the fragment (eleven literals, the round-8 resolution order included), no conditional Workspace paragraph left to condition, exactly ONE no-lane paragraph after the primary text, its three probes in order and BEFORE the rule, the show/log-only reading, the `gc.outcome=fail` + `gc.failure_class=no-lane` outcome, the `[[patches.agent]]` fix and the `prepare-worktree` carve-out; README Worker workspaces says the same and carries no `fallback`. `test_workers_never_choose_or_create_their_workspace` (line 82) exempts no paragraph any more, and the hunting rules gain `worktree add`, "create your worktree" and the round-4 opener.
- `gascity/tests/test_formula_assets.py` line 2431 `test_review_context_is_refreshed_after_a_fix_and_readers_read_the_current_commit` (reshaped): the setup's per-anchor write and its "no workflow-wide review commit"; the fix lane's per-anchor refresh with the ordering commit < refresh < key < release and "Touch no other source anchor's record or key"; every reader's "one record per source anchor", key-first/record-second, `gc bd show <source-anchor-id> --json`, and never `<workflow-root-id>`; the contract paragraph; grep-driven over every workflow step: no step writes `gc.review_commit` on `<workflow-root-id>`, the old key is absent from every step, the README and the fragment, the key holders are exactly the contract, the setup, the fix lane and the three readers; the README sentence. The enumeration row names the two new scenarios.
- `gascity/tests/test_lane_lifecycle.py` line 639 `test_two_source_anchors_keep_their_own_review_commits_when_one_is_fixed` (real git, temp dir, no network): two branches from main, neither commit an ancestor of the other; the setup records A1 on item 1 and A2 on item 2 (one record each in the context file, one key each); the fix lane takes item 1's branch, commits B1, refreshes item 1's record and key only, releases; item 2's record and key are exactly as the setup left them and A1 is gone from the context; each reader reads ITS anchor (B1, A2), detaches at it and sees its own files only; `B1:two.txt` does not exist, which is where one workflow-wide key would have sent item 2's reader; the key-absent fallback is per anchor too.
- line 594 `test_role_session_without_a_lane_reads_detached_creates_no_worktree_and_moves_nothing` (real git): `$GC_DIR` is the rig root and fails part 2; a read-only step reads the item by show/log and closes pass; a step that needs a checkout closes `fail` / `no-lane` naming `[[patches.agent]]`; after both, every file under the rig checkout, `.git/HEAD`, `for-each-ref`, the worktree list (still 3), the branch and `status --porcelain` are byte-identical, no third lane exists, the commit was never checked out.
- Proven to FAIL on eight mutations (a scratch copy of the tree): a `git worktree add` verb back in the no-lane paragraph; `no-lane` renamed; the rule moved before the boundary test; the round-8 fallback sentence back in the README; the setup writing `gc.review_commit` on `<workflow-root-id>`; `gc.build.review_commit` back in a reader; "Touch no other source anchor's record or key" dropped from the fix lane; the two-anchor scenario renamed. Control at the real text: 4 passed, 190 subtests.
- Full suite, `env -u GC_TEMPLATE uv run --with pytest --with PyYAML --with jsonschema python -m pytest tests gascity/tests -q` in the lane worktree at 2a6d66b: **336 passed, 8 skipped, 9730 subtests passed** (round 8: 335 / 8 / 9599). `git diff --check` clean. `pytest --collect-only gascity/tests/test_lane_lifecycle.py`: 7 tests collected.

**Judgment calls, flagged:** (1) The key is `gc.review_commit`, a new name, rather than `gc.build.review_commit` moved onto the anchor: `gc.build.*` are workflow-root artifact keys, and a new name makes "the old key is gone" a grep (the static row asserts the old name is absent from every step, the README and the fragment). (2) The boundary test is stated in the fragment itself (with `$GC_RIG_ROOT` as the rig root, the variable gc exports to every session) rather than referenced from `do-work/prepare-worktree`, because the fragment is every role's prompt, formula or not. (3) The fragment keeps one sentence for the do-work rig-root path (`prepare-worktree` step 5 "runs unchanged"), as the bead asked, so a city without lanes that runs do-work still gets its per-item worktree from that step, never from the prompt. (4) The readers' round-7 rig-root paragraphs stay: they are the fail-closed behaviour, not the fallback. (5) The lifecycle test models the bead store as a dict per anchor id and the context file as a real file with one record per anchor; git is real. (6) "Byte-identical" excludes `.git/index`, which `git status` itself refreshes; everything a session could move is compared. (7) **Twin only:** the acceptance lane's paragraph conflicted with upstream's `## Implementation Worktrees` sentences (kept word for word); on the twin the round-9 paragraph opens "The `## Implementation Worktrees` section carries one record per source anchor" instead of "The review context carries ...".

**Upstream twin:** #422 re-cut with the commit cherry-picked onto its own head `4812af0` (never from this PR's head): head `111f5f8`, one conflict (the acceptance lane, resolved as above), upstream's `## Implementation Worktrees` sentences in the acceptance, apply and test-evidence lanes kept word for word. On the twin, `test_formula_assets.py` + `test_worker_worktree.py` + `test_lane_lifecycle.py` + `tests/test_gc_role_worker_fragment.py`: 18 failed, 171 passed, 6321 subtests; base `4812af0`: 18 failed, 170 passed, 6190 subtests; failure ROW sets (FAILED + SUBFAILED, sorted) diffed: identical (the 18 pre-existing `test_implementation_review_check_*` rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


