### PR TITLE
fix(gascity): value-based verdict selection for design-review and gap-analysis check gates

### DIFF
--- a/gascity/assets/scripts/checks/design-review-approved.sh
+++ b/gascity/assets/scripts/checks/design-review-approved.sh
@@ -28,11 +28,22 @@ gmol() {   # root_id -> molecule-member JSON array
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    # unique_by sorts by id, so the union comes back in bead-id order. The
-    # verdict extractors below take `| last`, which must mean "most recently
-    # updated" -- without this re-sort the gate picks a verdict by id hash and
-    # can sit on a stale `iterate` forever while a newer `done` is ignored.
-    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id) | sort_by(.updated_at // "")' "$tmp"/*.json || rc=1
+    # unique_by sorts by id, so the union comes back in bead-id order, and
+    # that is the only order it has. `updated_at` is `omitempty,omitzero` on
+    # the reader's bead struct, so `gc ready --json` emits it on every row in
+    # some deployments and on none in others -- both measured: 56/56 rows on
+    # the PR #376 review root, 0/37 on a gc 1.4.1 rig store. The re-sort this
+    # line used to carry was live in one world and inert in the other, and in
+    # both it only staged row order for a positional `| last` downstream.
+    #
+    # It is gone because nothing in this file decides by row position any
+    # more. The verdict selection below (VERDICT_SELECTION) narrows to the
+    # highest attempt, then to owner-shaped beads, then to the newest
+    # `updated_at` -- each by value, and recency only when every candidate is
+    # dated -- and reduces whatever is left fail-closed. That selection is
+    # invariant under a permutation of bead ids, which is the property the old
+    # `| last` could not hold.
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
 }
@@ -61,9 +72,80 @@ if [ -z "$ROOT_ID" ]; then
     exit 1
 fi
 
-VERDICT=$(
+# The one approval vocabulary. Both consumers read this single definition and
+# both match case-insensitively: the jq verdict selection, which receives it
+# via --argjson, and the bash dispatch at the bottom of the file. A spelling
+# added here reaches every consumer at once -- in any case, because each
+# consumer downcases the entry as well as the candidate. Matching only the
+# candidate would have made a mixed-case entry silently unmatchable everywhere,
+# which is the same class of defect as the split vocabulary this replaced.
+APPROVAL_VERDICTS=(approve approved pass done)
+APPROVAL_VERDICTS_JSON="$(printf '%s\n' "${APPROVAL_VERDICTS[@]}" \
+  | jq -Rsc 'split("\n") | map(select(. != "")) | map(ascii_downcase)')"
+
+is_approved() {
+  local candidate known
+  candidate="$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')"
+  [ -n "$candidate" ] || return 1
+  for known in "${APPROVAL_VERDICTS[@]}"; do
+    if [ "$candidate" = "${known,,}" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# One bead owns the loop verdict: the six apply/confirm lanes contracted to
+# write the bare `design_review.verdict`. Every review lane instead writes a
+# suffixed key (`design_review.review_verdict`, `plan_review.founder_verdict`,
+# and siblings) and is contracted not to write the bare one, so a candidate
+# carrying any `^(design_review|plan_review)\..+_verdict$` key is a lane and is
+# dropped -- unless dropping the lanes would leave nothing, in which case every
+# candidate is kept. Narrowing may never starve the gate.
+#
+# Candidates are narrowed to the highest `attempt` first, because that is what
+# the old `sort_by(.attempt, .updated_at) | last` keyed on: putting the owner
+# partition first would let a stale owner from an earlier iteration outrank the
+# current iteration's only candidate, which today's gate never does.
+#
+# The survivors are then reduced to one value in two steps, neither of them
+# positional. First recency: keep only the survivors carrying the newest
+# `updated_at`, but only when every survivor is dated -- `updated_at` is
+# omitempty, and ranking a partially dated set would silently rank the undated
+# rows oldest, which is a guess, not a reading. Then, among values recency
+# could not separate, prefer a NON-approving one: resolving an unresolvable
+# dispute toward "approve" ships an unreviewed change, while resolving it
+# toward "iterate" costs one more loop iteration in a state that should not
+# occur anyway. Both steps are invariant under a permutation of bead ids.
+#
+# jq emits two lines: the selected verdict, then an optional ambiguity note --
+# emitted for every multi-candidate reduction, including a unanimous one.
+VERDICT_SELECTION=$(
     gmol "$ROOT_ID" |
-        jq -r --arg root "$ROOT_ID" --arg attempt "$ATTEMPT" --arg scope "$SCOPE_REF" --arg step "$STEP_ID" '
+        jq -r --arg root "$ROOT_ID" --arg attempt "$ATTEMPT" --arg scope "$SCOPE_REF" --arg step "$STEP_ID" \
+              --argjson approvals "$APPROVAL_VERDICTS_JSON" '
+            def is_approval($value):
+              (($value // "") | ascii_downcase) as $v
+              | any($approvals[]; . == $v);
+            # Narrow to the newest rows -- but only when every row is dated.
+            # `updated_at` is omitempty, and ranking a partially dated set would
+            # silently rank the undated rows oldest, which is a guess, not a
+            # reading. Selecting by max value rather than by position keeps ties
+            # whole for the reduction below.
+            def newest($rows):
+              ($rows | map(select((.updated_at // "") != "")) | length) as $dated
+              | if $dated > 0 and $dated == ($rows | length)
+                then ($rows | map(.updated_at) | max) as $max
+                  | ($rows | map(select(.updated_at == $max)))
+                else $rows
+                end;
+            # Reduce to one value, fail-closed: the lexicographically smallest
+            # distinct non-approving value if there is one, else the smallest
+            # approval.
+            def decide($rows):
+              ($rows | map(.value) | unique) as $vals
+              | ($vals | map(select(is_approval(.) | not))) as $blocking
+              | if ($blocking | length) > 0 then $blocking[0] else ($vals[0] // "") end;
             [
               .[]
               | select(.metadata["gc.root_bead_id"] == $root)
@@ -80,17 +162,56 @@ VERDICT=$(
                     ((.metadata["gc.continuation_group"] // "") == "design-review-fixes")
                   end
                 )
-              | {attempt: ((.metadata["gc.attempt"] // "0") | tonumber? // 0), updated_at: (.updated_at // ""), verdict: (.metadata["design_review.verdict"] // "")}
-              | select(.verdict != "")
-            ] | sort_by(.attempt, .updated_at) | last.verdict // ""
+              | select((.metadata["design_review.verdict"] // "") != "")
+              | {
+                  value: .metadata["design_review.verdict"],
+                  attempt: ((.metadata["gc.attempt"] // "0") | tonumber? // 0),
+                  updated_at: (.updated_at // ""),
+                  lane: (
+                    [(.metadata // {}) | keys[] | select(test("^(design_review|plan_review)\\..+_verdict$"))]
+                    | length > 0
+                  )
+                }
+            ] as $scoped
+            | (if ($scoped | length) > 0 then ($scoped | map(.attempt) | max) else 0 end) as $top
+            | ($scoped | map(select(.attempt == $top))) as $candidates
+            | ($candidates | map(select(.lane | not))) as $owners
+            | (if ($owners | length) > 0 then $owners else $candidates end) as $surviving
+            | ($surviving | map(.value) | unique) as $values
+            | newest($surviving) as $current
+            | decide($current) as $verdict
+            | (
+                if (($current | map(.value) | unique | length) > 1) then
+                  "fail-closed among \($current | map(.value) | unique | length) values"
+                elif (($current | length) < ($surviving | length)) then
+                  "newest updated_at"
+                else
+                  "unanimous"
+                end
+              ) as $basis
+            | (
+                if ($owners | length) > 1 then
+                  "design review check: \($owners | length) owner-shaped beads carry design_review.verdict at attempt \($top) (values: \($values | join(", "))); selected \"\($verdict)\" (\($basis))"
+                elif ($owners | length) == 0 and ($surviving | length) > 1 then
+                  "design review check: no owner-shaped bead at attempt \($top); reduced \($surviving | length) lane candidates (values: \($values | join(", "))); selected \"\($verdict)\" (\($basis))"
+                else
+                  ""
+                end
+              ) as $note
+            | "\($verdict)\n\($note)"
         '
 )
+VERDICT=$(printf '%s\n' "$VERDICT_SELECTION" | sed -n '1p')
+VERDICT_NOTE=$(printf '%s\n' "$VERDICT_SELECTION" | sed -n '2p')
+if [ -n "$VERDICT_NOTE" ]; then
+    echo "$VERDICT_NOTE" >&2
+fi
 
+if is_approved "$VERDICT"; then
+    echo "Design review approved"
+    exit 0
+fi
 case "$VERDICT" in
-    done|approved|pass)
-        echo "Design review approved"
-        exit 0
-        ;;
     iterate|fail|retry|"")
         echo "Design review needs another pass"
         exit 1

--- a/gascity/assets/scripts/checks/gap-analysis-approved.sh
+++ b/gascity/assets/scripts/checks/gap-analysis-approved.sh
@@ -26,11 +26,20 @@ gmol() {   # root_id -> molecule-member JSON array
         echo "gmol: gc ready failed for status: $(tr '\n' ' ' <"$tmp/failed")" >&2
         rc=1
     fi
-    # unique_by sorts by id, so the union comes back in bead-id order. The
-    # verdict extractors below take `| last`, which must mean "most recently
-    # updated" -- without this re-sort the gate picks a verdict by id hash and
-    # can sit on a stale `iterate` forever while a newer `done` is ignored.
-    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id) | sort_by(.updated_at // "")' "$tmp"/*.json || rc=1
+    # unique_by sorts by id, so the union comes back in bead-id order, and
+    # that is the only order it has. `updated_at` is `omitempty,omitzero` on
+    # the reader's bead struct, so `gc ready --json` emits it on every row in
+    # some deployments and on none in others -- both measured: 56/56 rows on
+    # the PR #376 review root, 0/37 on a gc 1.4.1 rig store. The re-sort this
+    # line used to carry was live in one world and inert in the other, and in
+    # both it only staged row order for a positional `| last` downstream.
+    #
+    # It is gone because nothing in this file decides by row position any
+    # more. The verdict selection below (VERDICT_SELECTION) narrows to the
+    # newest `updated_at` by value, and only when every candidate is dated,
+    # then reduces what is left fail-closed; the report check (REPORTS) walks
+    # every distinct report path at the attempt instead of the id-last one.
+    jq -s 'map(select(type=="array")) | add // [] | unique_by(.id)' "$tmp"/*.json || rc=1
     rm -rf "$tmp"
     return "$rc"
 }
@@ -56,6 +65,28 @@ metadata_value() {
   ' 2>/dev/null
 }
 
+# The one approval vocabulary, shared with design-review-approved.sh and
+# implementation-review-approved.sh. Both consumers here -- the jq verdict
+# selection and the bash dispatch -- read this single definition and match
+# case-insensitively. This gate used to accept `done` alone. It now reads the
+# shared vocabulary; no writer of `gap_analysis.verdict` exists in the
+# repository, so no live loop changes behavior.
+APPROVAL_VERDICTS=(approve approved pass done)
+APPROVAL_VERDICTS_JSON="$(printf '%s\n' "${APPROVAL_VERDICTS[@]}" \
+  | jq -Rsc 'split("\n") | map(select(. != "")) | map(ascii_downcase)')"
+
+is_approved() {
+  local candidate known
+  candidate="$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')"
+  [ -n "$candidate" ] || return 1
+  for known in "${APPROVAL_VERDICTS[@]}"; do
+    if [ "$candidate" = "${known,,}" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 GC_ERR="$(mktemp)"
 # EXIT alone does not fire on an untrapped signal, and check gates run under a
 # documented 10m dispatcher budget -- timeout kills are an expected path, not a
@@ -71,30 +102,84 @@ fi
 
 MATCHES="$(gmol "$PARENT_ROOT")"
 
-VERDICT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
+# No writer of `gap_analysis.verdict` exists and there is no lane grammar to
+# detect, so there is no owner partition here; the gate reduces by value
+# alone. jq emits two lines: the selected verdict, then an optional note.
+VERDICT_SELECTION="$(printf '%s\n' "$MATCHES" | jq -r \
+  --arg attempt "$ATTEMPT" \
+  --argjson approvals "$APPROVAL_VERDICTS_JSON" '
+  def is_approval($value):
+    (($value // "") | ascii_downcase) as $v
+    | any($approvals[]; . == $v);
+  def newest($rows):
+    ($rows | map(select((.updated_at // "") != "")) | length) as $dated
+    | if $dated > 0 and $dated == ($rows | length)
+      then ($rows | map(.updated_at) | max) as $max
+        | ($rows | map(select(.updated_at == $max)))
+      else $rows
+      end;
+  def decide($rows):
+    ($rows | map(.value) | unique) as $vals
+    | ($vals | map(select(is_approval(.) | not))) as $blocking
+    | if ($blocking | length) > 0 then $blocking[0] else ($vals[0] // "") end;
   [
     .[]
     | select((.metadata["gc.attempt"] // "") == $attempt)
     | select((.metadata["gap_analysis.verdict"] // "") != "")
-    | .metadata["gap_analysis.verdict"]
-  ] | last // ""
+    | {value: .metadata["gap_analysis.verdict"], updated_at: (.updated_at // "")}
+  ] as $candidates
+  | ($candidates | map(.value) | unique) as $values
+  | newest($candidates) as $current
+  | decide($current) as $verdict
+  | (
+      if (($current | map(.value) | unique | length) > 1) then
+        "fail-closed among \($current | map(.value) | unique | length) values"
+      elif (($current | length) < ($candidates | length)) then
+        "newest updated_at"
+      else
+        "unanimous"
+      end
+    ) as $basis
+  | (
+      if ($candidates | length) > 1 then
+        "gap check: \($candidates | length) beads carry gap_analysis.verdict at attempt \($attempt) (values: \($values | join(", "))); selected \"\($verdict)\" (\($basis))"
+      else
+        ""
+      end
+    ) as $note
+  | "\($verdict)\n\($note)"
 ' 2>/dev/null)"
+VERDICT="$(printf '%s\n' "$VERDICT_SELECTION" | sed -n '1p')"
+VERDICT_NOTE="$(printf '%s\n' "$VERDICT_SELECTION" | sed -n '2p')"
+if [ -n "$VERDICT_NOTE" ]; then
+  echo "$VERDICT_NOTE" >&2
+fi
 
-REPORT="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
+REPORTS="$(printf '%s\n' "$MATCHES" | jq -r --arg attempt "$ATTEMPT" '
   [
     .[]
     | select((.metadata["gc.attempt"] // "") == $attempt)
-    | select((.metadata["gap_analysis.report_path"] // "") != "")
-    | .metadata["gap_analysis.report_path"]
-  ] | last // ""
+    | (.metadata["gap_analysis.report_path"] // "")
+    | select(. != "")
+  ] | unique | .[]
 ' 2>/dev/null)"
 
-if [ "$VERDICT" != "done" ]; then
+if ! is_approved "$VERDICT"; then
+  case "$VERDICT" in
+    iterate|fail|retry|"") : ;;
+    *) echo "gap check: unknown gap-analysis verdict: $VERDICT" >&2 ;;
+  esac
   echo "Gap analysis needs another iteration: ${VERDICT:-missing verdict}"
   exit 1
 fi
 
-if [ -n "$REPORT" ]; then
+# Every distinct report recorded at this attempt is checked, not the id-last
+# one: the severity grep can only fail the gate, so a stale report at the same
+# attempt costs one more iteration rather than hiding a critical finding.
+# `unique` sorts the paths, so the first hit is the same whichever bead is
+# id-last.
+while IFS= read -r REPORT; do
+  [ -n "$REPORT" ] || continue
   if [ ! -f "$REPORT" ] && [ -n "${GC_WORK_DIR:-}" ] && [ -f "$GC_WORK_DIR/$REPORT" ]; then
     REPORT="$GC_WORK_DIR/$REPORT"
   fi
@@ -102,7 +187,7 @@ if [ -n "$REPORT" ]; then
     echo "Gap analysis report still contains critical/blocker/major findings: $REPORT"
     exit 1
   fi
-fi
+done <<<"$REPORTS"
 
 echo "Gap analysis approved"
 exit 0

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -5402,7 +5402,12 @@ description = "Override sink that writes the base triage report contract."
                         self.assertIn(expected_out, result.stdout)
 
     def _run_sibling_gate(
-        self, script_name: str, *, show_json: str, list_json: str
+        self,
+        script_name: str,
+        *,
+        show_json: str,
+        list_json: str,
+        extra_env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess:
         root = pathlib.Path(__file__).resolve().parents[1]
         script = root / "assets" / "scripts" / "checks" / script_name
@@ -5424,10 +5429,523 @@ description = "Override sink that writes the base triage report contract."
                 "BD_LIST_JSON": str(list_path),
                 "GC_BEAD_ID": "loop",
                 "GC_ITERATION": "1",
+                **(extra_env or {}),
             }
             return subprocess.run(
                 [str(script)], env=env, text=True, capture_output=True, check=False
             )
+
+    @staticmethod
+    def _rig_row(
+        bead_id: str,
+        metadata: dict,
+        *,
+        status: str = "closed",
+        updated_at: str | None = None,
+    ) -> dict:
+        """A row shaped like this rig's `gc ready --json` reader: eight keys,
+
+        `updated_at` present only when given. Do not chase the live superset
+        (`dependencies`, `assignee`) -- the eight-key fixture is the contract
+        TS-3/AC-003 pin, and a ninth key here would stop proving what the rig
+        actually emits.
+        """
+        row = {
+            "id": bead_id,
+            "status": status,
+            "created_at": "2026-09-01T00:00:00Z",
+            "issue_type": "task",
+            "priority": 1,
+            "title": bead_id,
+            "description": "",
+            "metadata": metadata,
+        }
+        if updated_at is not None:
+            row["updated_at"] = updated_at
+        return row
+
+    def test_design_review_check_fails_closed_when_recency_is_unknown(self) -> None:
+        """REQ-002/REQ-004: undated disagreement is never ranked by id order."""
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        base_metadata = {
+            "gc.root_bead_id": "root",
+            "gc.attempt": "1",
+            "gc.continuation_group": "design-review-fixes",
+        }
+
+        def row(bead_id: str, verdict: str, updated_at: str | None = None) -> dict:
+            return self._rig_row(
+                bead_id,
+                {**base_metadata, "design_review.verdict": verdict},
+                updated_at=updated_at,
+            )
+
+        with self.subTest(case="id-last done beats id-first iterate, both undated"):
+            list_json = json.dumps([row("gcg-aaa", "iterate"), row("gcg-zzz", "done")])
+            result = self._run_sibling_gate(
+                "design-review-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("Design review needs another pass", result.stdout)
+            self.assertIn('selected "iterate" (fail-closed among 2 values)', result.stderr)
+
+        with self.subTest(case="values swapped, still undated"):
+            list_json = json.dumps([row("gcg-aaa", "done"), row("gcg-zzz", "iterate")])
+            result = self._run_sibling_gate(
+                "design-review-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("Design review needs another pass", result.stdout)
+
+        with self.subTest(case="one dated, one undated -- not ranked"):
+            list_json = json.dumps(
+                [
+                    row("gcg-aaa", "done", updated_at="2026-08-13T03:00:00Z"),
+                    row("gcg-zzz", "iterate"),
+                ]
+            )
+            result = self._run_sibling_gate(
+                "design-review-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn('selected "iterate" (fail-closed among 2 values)', result.stderr)
+
+        with self.subTest(case="both undated, agree"):
+            list_json = json.dumps([row("gcg-aaa", "done"), row("gcg-zzz", "done")])
+            result = self._run_sibling_gate(
+                "design-review-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("Design review approved", result.stdout)
+
+    def test_gap_analysis_check_fails_closed_when_recency_is_unknown(self) -> None:
+        """REQ-002/REQ-004: the same guard for the gap-analysis gate."""
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        base_metadata = {"gc.root_bead_id": "root", "gc.attempt": "1"}
+
+        def row(bead_id: str, verdict: str, updated_at: str | None = None) -> dict:
+            return self._rig_row(
+                bead_id,
+                {**base_metadata, "gap_analysis.verdict": verdict},
+                updated_at=updated_at,
+            )
+
+        with self.subTest(case="id-last done beats id-first iterate, both undated"):
+            list_json = json.dumps([row("gcg-aaa", "iterate"), row("gcg-zzz", "done")])
+            result = self._run_sibling_gate(
+                "gap-analysis-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("Gap analysis needs another iteration: iterate", result.stdout)
+            self.assertIn('selected "iterate" (fail-closed among 2 values)', result.stderr)
+
+        with self.subTest(case="values swapped, still undated"):
+            list_json = json.dumps([row("gcg-aaa", "done"), row("gcg-zzz", "iterate")])
+            result = self._run_sibling_gate(
+                "gap-analysis-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("Gap analysis needs another iteration: iterate", result.stdout)
+
+        with self.subTest(case="one dated, one undated -- not ranked"):
+            list_json = json.dumps(
+                [
+                    row("gcg-aaa", "done", updated_at="2026-08-13T03:00:00Z"),
+                    row("gcg-zzz", "iterate"),
+                ]
+            )
+            result = self._run_sibling_gate(
+                "gap-analysis-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn('selected "iterate" (fail-closed among 2 values)', result.stderr)
+
+        with self.subTest(case="both undated, agree"):
+            list_json = json.dumps([row("gcg-aaa", "done"), row("gcg-zzz", "done")])
+            result = self._run_sibling_gate(
+                "gap-analysis-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("Gap analysis approved", result.stdout)
+
+    def test_design_review_check_is_invariant_under_id_permutation(self) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        base_metadata = {
+            "gc.root_bead_id": "root",
+            "gc.attempt": "1",
+            "gc.continuation_group": "design-review-fixes",
+        }
+
+        def row(bead_id: str, verdict: str) -> dict:
+            return self._rig_row(bead_id, {**base_metadata, "design_review.verdict": verdict})
+
+        list_json_a = json.dumps([row("gcg-aaa", "iterate"), row("gcg-zzz", "done")])
+        list_json_b = json.dumps([row("gcg-aaa", "done"), row("gcg-zzz", "iterate")])
+
+        result_a = self._run_sibling_gate(
+            "design-review-approved.sh", show_json=show_json, list_json=list_json_a
+        )
+        result_b = self._run_sibling_gate(
+            "design-review-approved.sh", show_json=show_json, list_json=list_json_b
+        )
+
+        self.assertEqual(result_a.returncode, 1, result_a.stdout + result_a.stderr)
+        self.assertEqual(
+            (result_a.returncode, result_a.stdout), (result_b.returncode, result_b.stdout)
+        )
+
+    def test_gap_analysis_check_is_invariant_under_id_permutation(self) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        base_metadata = {"gc.root_bead_id": "root", "gc.attempt": "1"}
+
+        def row(bead_id: str, verdict: str) -> dict:
+            return self._rig_row(bead_id, {**base_metadata, "gap_analysis.verdict": verdict})
+
+        list_json_a = json.dumps([row("gcg-aaa", "iterate"), row("gcg-zzz", "done")])
+        list_json_b = json.dumps([row("gcg-aaa", "done"), row("gcg-zzz", "iterate")])
+
+        result_a = self._run_sibling_gate(
+            "gap-analysis-approved.sh", show_json=show_json, list_json=list_json_a
+        )
+        result_b = self._run_sibling_gate(
+            "gap-analysis-approved.sh", show_json=show_json, list_json=list_json_b
+        )
+
+        self.assertEqual(result_a.returncode, 1, result_a.stdout + result_a.stderr)
+        self.assertEqual(
+            (result_a.returncode, result_a.stdout), (result_b.returncode, result_b.stdout)
+        )
+
+    def test_design_review_check_accepts_every_approval_spelling(self) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        for spelling in ("approve", "Approve", "approved", "pass", "done", "DONE"):
+            with self.subTest(verdict=spelling):
+                list_json = json.dumps(
+                    [
+                        self._rig_row(
+                            "gcg-aaa",
+                            {
+                                "gc.root_bead_id": "root",
+                                "gc.attempt": "1",
+                                "gc.continuation_group": "design-review-fixes",
+                                "design_review.verdict": spelling,
+                            },
+                        )
+                    ]
+                )
+                result = self._run_sibling_gate(
+                    "design-review-approved.sh", show_json=show_json, list_json=list_json
+                )
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("Design review approved", result.stdout)
+
+    def test_gap_analysis_check_accepts_every_approval_spelling(self) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        for spelling in ("approve", "Approve", "approved", "pass", "done", "DONE"):
+            with self.subTest(verdict=spelling):
+                list_json = json.dumps(
+                    [
+                        self._rig_row(
+                            "gcg-aaa",
+                            {
+                                "gc.root_bead_id": "root",
+                                "gc.attempt": "1",
+                                "gap_analysis.verdict": spelling,
+                            },
+                        )
+                    ]
+                )
+                result = self._run_sibling_gate(
+                    "gap-analysis-approved.sh", show_json=show_json, list_json=list_json
+                )
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("Gap analysis approved", result.stdout)
+
+    def test_design_review_check_rejects_every_non_approving_spelling(self) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        for spelling in ("iterate", "fail", "retry", ""):
+            with self.subTest(verdict=spelling or "<empty>"):
+                if spelling:
+                    list_json = json.dumps(
+                        [
+                            self._rig_row(
+                                "gcg-aaa",
+                                {
+                                    "gc.root_bead_id": "root",
+                                    "gc.attempt": "1",
+                                    "gc.continuation_group": "design-review-fixes",
+                                    "design_review.verdict": spelling,
+                                },
+                            )
+                        ]
+                    )
+                else:
+                    list_json = "[]"
+                result = self._run_sibling_gate(
+                    "design-review-approved.sh", show_json=show_json, list_json=list_json
+                )
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn("Design review needs another pass", result.stdout)
+
+        with self.subTest(verdict="bogus"):
+            list_json = json.dumps(
+                [
+                    self._rig_row(
+                        "gcg-aaa",
+                        {
+                            "gc.root_bead_id": "root",
+                            "gc.attempt": "1",
+                            "gc.continuation_group": "design-review-fixes",
+                            "design_review.verdict": "bogus",
+                        },
+                    )
+                ]
+            )
+            result = self._run_sibling_gate(
+                "design-review-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("bogus", result.stderr)
+
+    def test_gap_analysis_check_rejects_every_non_approving_spelling(self) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        for spelling in ("iterate", "fail", "retry", ""):
+            with self.subTest(verdict=spelling or "<empty>"):
+                if spelling:
+                    list_json = json.dumps(
+                        [
+                            self._rig_row(
+                                "gcg-aaa",
+                                {
+                                    "gc.root_bead_id": "root",
+                                    "gc.attempt": "1",
+                                    "gap_analysis.verdict": spelling,
+                                },
+                            )
+                        ]
+                    )
+                else:
+                    list_json = "[]"
+                result = self._run_sibling_gate(
+                    "gap-analysis-approved.sh", show_json=show_json, list_json=list_json
+                )
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn("Gap analysis needs another iteration", result.stdout)
+
+        with self.subTest(verdict="bogus"):
+            list_json = json.dumps(
+                [
+                    self._rig_row(
+                        "gcg-aaa",
+                        {
+                            "gc.root_bead_id": "root",
+                            "gc.attempt": "1",
+                            "gap_analysis.verdict": "bogus",
+                        },
+                    )
+                ]
+            )
+            result = self._run_sibling_gate(
+                "gap-analysis-approved.sh", show_json=show_json, list_json=list_json
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("bogus", result.stderr)
+
+    def test_design_review_check_takes_owner_iterate_over_lane_done(self) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        base_metadata = {
+            "gc.root_bead_id": "root",
+            "gc.attempt": "1",
+            "gc.continuation_group": "design-review-fixes",
+        }
+
+        def owner_row(bead_id: str) -> dict:
+            return self._rig_row(bead_id, {**base_metadata, "design_review.verdict": "iterate"})
+
+        def lane_row(bead_id: str) -> dict:
+            return self._rig_row(
+                bead_id,
+                {
+                    **base_metadata,
+                    "design_review.verdict": "done",
+                    "design_review.review_verdict": "approve",
+                },
+            )
+
+        for label, owner_id, lane_id in (
+            ("owner id-first", "gcg-aaa", "gcg-zzz"),
+            ("owner id-last", "gcg-zzz", "gcg-aaa"),
+        ):
+            with self.subTest(order=label):
+                list_json = json.dumps([owner_row(owner_id), lane_row(lane_id)])
+                result = self._run_sibling_gate(
+                    "design-review-approved.sh", show_json=show_json, list_json=list_json
+                )
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn("Design review needs another pass", result.stdout)
+
+    def test_design_review_check_notes_lane_fallback_without_owner(self) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        base_metadata = {
+            "gc.root_bead_id": "root",
+            "gc.attempt": "1",
+            "gc.continuation_group": "design-review-fixes",
+        }
+        list_json = json.dumps(
+            [
+                self._rig_row(
+                    "gcg-aaa",
+                    {
+                        **base_metadata,
+                        "design_review.verdict": "done",
+                        "plan_review.founder_verdict": "approve",
+                    },
+                ),
+                self._rig_row(
+                    "gcg-zzz",
+                    {
+                        **base_metadata,
+                        "design_review.verdict": "done",
+                        "plan_review.design_verdict": "approve",
+                    },
+                ),
+            ]
+        )
+        result = self._run_sibling_gate(
+            "design-review-approved.sh", show_json=show_json, list_json=list_json
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Design review approved", result.stdout)
+        self.assertIn("no owner-shaped bead at attempt 1", result.stderr)
+        self.assertIn("reduced 2 lane candidates", result.stderr)
+
+    def test_design_review_check_prefers_the_highest_attempt_before_recency(self) -> None:
+        show_json = json.dumps([{"id": "loop", "metadata": {"gc.root_bead_id": "root"}}])
+        base_metadata = {"gc.root_bead_id": "root", "gc.continuation_group": "design-review-fixes"}
+
+        def attempt1_row(bead_id: str) -> dict:
+            return self._rig_row(
+                bead_id,
+                {**base_metadata, "gc.attempt": "1", "design_review.verdict": "done"},
+                updated_at="2026-08-13T05:00:00Z",
+            )
+
+        def attempt2_row(bead_id: str) -> dict:
+            return self._rig_row(
+                bead_id,
+                {**base_metadata, "gc.attempt": "2", "design_review.verdict": "iterate"},
+                updated_at="2026-08-13T01:00:00Z",
+            )
+
+        for label, ordering in (
+            ("attempt-1 id-first", [attempt1_row("gcg-aaa"), attempt2_row("gcg-zzz")]),
+            ("attempt-1 id-last", [attempt2_row("gcg-aaa"), attempt1_row("gcg-zzz")]),
+        ):
+            with self.subTest(order=label):
+                list_json = json.dumps(ordering)
+                result = self._run_sibling_gate(
+                    "design-review-approved.sh", show_json=show_json, list_json=list_json
+                )
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn("Design review needs another pass", result.stdout)
+
+    def test_gap_analysis_check_checks_every_report_at_the_attempt(self) -> None:
+        show_json = json.dumps(
+            [{"id": "loop", "metadata": {"gc.root_bead_id": "root", "gc.attempt": "1"}}]
+        )
+        base_metadata = {"gc.root_bead_id": "root", "gc.attempt": "1"}
+
+        with tempfile.TemporaryDirectory() as td:
+            work_dir = pathlib.Path(td)
+            (work_dir / "report-a.md").write_text("all clear\n", encoding="utf-8")
+            (work_dir / "report-b.md").write_text("severity: critical\n", encoding="utf-8")
+
+            def row(bead_id: str, report_path: str) -> dict:
+                return self._rig_row(
+                    bead_id,
+                    {
+                        **base_metadata,
+                        "gap_analysis.verdict": "done",
+                        "gap_analysis.report_path": report_path,
+                    },
+                )
+
+            for label, ordering in (
+                (
+                    "critical id-last",
+                    [row("gcg-aaa", "report-a.md"), row("gcg-zzz", "report-b.md")],
+                ),
+                (
+                    "critical id-first",
+                    [row("gcg-aaa", "report-b.md"), row("gcg-zzz", "report-a.md")],
+                ),
+            ):
+                with self.subTest(order=label):
+                    list_json = json.dumps(ordering)
+                    result = self._run_sibling_gate(
+                        "gap-analysis-approved.sh",
+                        show_json=show_json,
+                        list_json=list_json,
+                        extra_env={"GC_WORK_DIR": str(work_dir)},
+                    )
+                    self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                    self.assertIn(
+                        "still contains critical/blocker/major findings", result.stdout
+                    )
+
+            with self.subTest(order="both clean"):
+                list_json = json.dumps(
+                    [row("gcg-aaa", "report-a.md"), row("gcg-zzz", "report-a.md")]
+                )
+                result = self._run_sibling_gate(
+                    "gap-analysis-approved.sh",
+                    show_json=show_json,
+                    list_json=list_json,
+                    extra_env={"GC_WORK_DIR": str(work_dir)},
+                )
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("Gap analysis approved", result.stdout)
+
+    def test_design_review_gap_analysis_and_implementation_review_checks_share_one_vocabulary(
+        self,
+    ) -> None:
+        root = pathlib.Path(__file__).resolve().parents[1]
+        checks_dir = root / "assets" / "scripts" / "checks"
+        definitions = {}
+        for name in (
+            "design-review-approved.sh",
+            "gap-analysis-approved.sh",
+            "implementation-review-approved.sh",
+        ):
+            lines = [
+                line
+                for line in (checks_dir / name).read_text(encoding="utf-8").splitlines()
+                if line.startswith("APPROVAL_VERDICTS=(")
+            ]
+            self.assertEqual(len(lines), 1, f"{name}: {lines}")
+            definitions[name] = lines[0]
+
+        self.assertEqual(len(set(definitions.values())), 1, definitions)
 
     def test_gap_analysis_check_takes_the_newest_verdict_not_the_id_last_one(self) -> None:
         """The gap-analysis gate decides by recency -- pinned before it is ported.


### PR DESCRIPTION
## Summary

`design-review-approved.sh` and `gap-analysis-approved.sh` are Ralph
loop-exit check gates in the `gascity` pack. Like `implementation-review-approved.sh`
before PR #376, each decided its verdict by list position rather than by
value, and each kept its own narrow approval vocabulary. This PR ports the
PR #376 repair pattern to both siblings, re-derived from each gate's own
consumers.

**The `updated_at` finding is deployment-specific, and the fix has to be
correct in both worlds.** The reader's bead struct declares
`UpdatedAt time.Time \`json:"updated_at,omitempty,omitzero"\``, so whether a
`gc ready --json` row carries `updated_at` depends on the deployment:

| deployment | `updated_at` on rows |
| --- | --- |
| this rig (`gc 1.4.1`, rig store `apicity`) | absent on 37/37 rows measured |
| the environment that reviewed PR #376 | present on 56/56 rows |

The `sort_by(.updated_at // "")` each `gmol()` carried was live in one world
and inert in the other; in both it only staged row order for a positional
`| last` downstream. **The sorts are removed together with value-based
recency, not merely deleted** — deleting a sort alone (as an earlier draft of
this change proposed) turns the landed recency guard red in both directions,
exactly as PR #376's merger note warned.

**`gap-analysis-approved.sh` widens its approval vocabulary** from `done`
alone to the shared `approve|approved|pass|done` set (case-insensitive), the
same vocabulary `design-review-approved.sh` and `implementation-review-approved.sh`
use. No writer of `gap_analysis.verdict` exists in the repository today, so
this changes no live loop's behavior.

Three files change, all under `gascity/`:
`assets/scripts/checks/design-review-approved.sh`,
`assets/scripts/checks/gap-analysis-approved.sh`, and
`tests/test_formula_assets.py`. The only edit to an existing test is a
two-line `extra_env` keyword added to `_run_sibling_gate` (mirroring
`_run_implementation_review_check`); every existing call to it is unchanged,
and no existing test's body is modified.

References: `ac-g979jx` (this rig's tracking bead for this work).
`mc-57k9j` is referenced by PR #376 as the sibling work; that id is not
resolvable from this rig's store, so I can't close it from here — could a
maintainer close it on merge if it's the tracking issue for this PR?

## Evidence

Base: `upstream/main` @ `e72252ec4936cb4b71abdcf5c8edb3f4e2975d6e`, script
sha256 `88d2182c3d33a77dacccf9ef6129058b952af0c3d4b4828948ca7a4a726a7d23`
(design-review) and `4701cd1fb1157a8d23b10ddb1d7776efa762d5f2ec0bd867cdccf43a4de65889`
(gap-analysis), matching the tracking bead's pin table.

| Step | Command | Result |
| --- | --- | --- |
| Baseline | `pytest gascity/tests -q -k 'design_review or gap_analysis'` at branch point | 10 passed, 198 deselected, 4 subtests |
| Test-only commit | same, after the test commit alone | 11 failed, 12 passed |
| After both script repairs | same | 23 passed |
| Full suite | `pytest gascity/tests -q` | 221 passed (208 at base + 13 new), 9498 subtests, exit 0 |
| Grep | `grep -n 'sort_by(.updated_at' assets/scripts/checks/*.sh` | exit 1 (no match outside a test docstring) |
| Grep | `grep -n 'must mean' assets/scripts/checks/{design-review,gap-analysis}-approved.sh` | exit 1 (no match) |
| `go test .` | at repo root | ok |
| `bash -n` | both scripts | pass; both remain mode 100755 |
| Diff scope | `git diff --stat upstream/main...HEAD` | exactly the three files above |

The two landed recency tests (`test_gap_analysis_check_takes_the_newest_verdict_not_the_id_last_one`,
`test_design_review_check_takes_the_newest_verdict_not_the_id_last_one`) are
unmodified and pass (2 passed). `git diff upstream/main -- gascity/tests/test_formula_assets.py`
shows additions only, apart from the two-line `extra_env` edit noted above;
none of the ten existing sibling tests were touched.

## Follow-up

Filed `ac-lxp8s2` in this rig's issue tracker (not resolvable from
outside that store) covering three items intentionally left out of this PR's
scope:

- `implementation-review-approved.sh`'s two documented id-order residuals
  (lane-status `| last` per key, report-mode path `| last`) and its own
  `gmol()` comment, whose "absent only on a bead never updated" claim the
  0/37 measurement above falsifies.
- `gastown/assets/scripts/checks/design-review-approved.sh` — a different
  pack's gate with its own reader and its own `done|approved|pass)` arm that
  also lacks `approve`.
- Why one deployment's `gc ready --json` reader emits `updated_at` on every
  row and this one emits it on none (a `gc` binary question).

No pack release, version bump, or registry stamp is included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9YbbCmvNGRy8mm11fEocu
