### PR TITLE
feat(gascity): codex-infisical-shim.sh — source of record for the Codex provider shim (gp-3or1)

### DIFF
--- a/gascity/README.md
+++ b/gascity/README.md
@@ -220,11 +220,15 @@ failing helper leaves the token unset and prints one WARN, an `exit`, a
 `set --`, a trace or an EXIT trap in the helper cannot reach the shim or the
 session output, the session starts either way); then it execs the real codex
 with argv intact. It never execs itself: it locates itself with shell
-builtins only and refuses to run when it cannot, every PATH entry that
-resolves to its own directory is removed first (empty entries kept; when
-nothing survives, PATH becomes `/dev/null`, never the empty string bash reads
-as the current directory), and no codex left on PATH is an error (exit 127),
-never a loop.
+builtins only and refuses to run when it cannot, every PATH entry that is its
+own directory is removed first (by inode, so symlinked, relative and
+doubled-slash spellings count; empty entries kept; when nothing survives,
+PATH becomes `/dev/null`, never the empty string bash reads as the current
+directory), the target is the executable file `type -P` finds (an exported
+function or alias named `codex` is ignored) and that checked path is what
+runs, and no codex left on PATH is an error (exit 127), never a loop.
+Inherited shell options reach codex as they came: xtrace is off while the
+token is handled and back on for the exec, noglob is left as found.
 
 Install it as the city's shim, in its own directory (gc does not sync a
 pack's `assets/scripts` anywhere), with the per-city settings in a
@@ -285,9 +289,11 @@ test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = <that md5>
 `gascity/tests/test_codex_infisical_shim.py` holds the contract: fail-open
 with the helper absent, present, failing, exiting, tracing, trapping,
 printing or rewriting argv; only the token crosses over; argv intact; PATH
-pruned through symlinked and relative aliases with empty entries kept and
-never emptied; the self-exec refusals, with no utility on PATH and under
-CDPATH; the settings file never evaluated; the install recipe above run from
+pruned through symlinked, relative and doubled-slash aliases with empty
+entries kept and never emptied; the self-exec refusals, with no utility on
+PATH, under CDPATH and with an exported function named `codex`; inherited
+xtrace never printing the token and inherited xtrace and noglob reaching
+codex; the settings file never evaluated; the install recipe above run from
 a fresh directory, the md5 recording refusing a bad pin and the check failing
 on a missing file.
 

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -211,20 +211,26 @@ so a city that gives its Codex role agents an Infisical machine identity mints
 the token at session start. An agent's `env` map is static and `pre_start`
 runs in its own process; the one city-side place a freshly minted value can
 enter the session environment is a provider `command` wrapper. This pack
-ships that wrapper as `assets/scripts/codex-infisical-shim.sh`: it sources
-`$HOME/.config/infisical-agent/token.sh` fail-open when `INFISICAL_TOKEN` is
-unset (a missing file is silent, a failing login leaves the token unset and
-prints one WARN, the session starts either way), then execs the real codex
-with argv intact. It never execs itself: every PATH entry that resolves to
-its own directory is removed first, and no codex left on PATH is an error
-(exit 127), never a loop. The token is never echoed.
+ships that wrapper as `assets/scripts/codex-infisical-shim.sh`: when
+`INFISICAL_TOKEN` is unset or empty it sources
+`$HOME/.config/infisical-agent/token.sh` fail-open, in a subshell with the
+helper's output discarded, and carries over exactly one value, the token the
+helper exported (a missing file is silent, a failing helper leaves the token
+unset and prints one WARN, an `exit` or a `set --` in the helper cannot reach
+the shim, the session starts either way); then it execs the real codex with
+argv intact. It never execs itself: it locates itself with shell builtins
+only and refuses to run when it cannot, every PATH entry that resolves to its
+own directory is removed first, and no codex left on PATH is an error (exit
+127), never a loop. Nothing the helper prints reaches the session output.
 
 Install it as the city's shim, in its own directory (gc does not sync a
 pack's `assets/scripts` anywhere), with the per-city settings in a
-`codex.env` beside it; the environment overrides the file, the file is plain
-`KEY=VALUE` lines and never evaluated:
+`codex.env` beside it. A variable present in the environment, even empty,
+wins over the file; the file is plain `KEY=VALUE` lines and never evaluated;
+a blank value means "not set":
 
 ```sh
+mkdir -p "$CITY/.gc/shims/codex-astra"
 install -m 0755 path/to/gascity/assets/scripts/codex-infisical-shim.sh \
   "$CITY/.gc/shims/codex-astra/codex"
 cat > "$CITY/.gc/shims/codex-astra/codex.env" <<'EOT'
@@ -260,18 +266,24 @@ INFISICAL_PROJECT_ID = "<project id>"
 ```
 
 The installed copy is city runtime state; the file here is its source of
-record. A city verifies at each wake that the installed shim is this file,
-by md5 against the pack checkout at the installed pin:
+record. A city verifies at each wake that the installed shim is this file at
+the installed pin. Record the canonical md5 once, from the pack checkout at
+that pin, and compare the installed file to the literal, so a missing file or
+a missing md5 tool fails the check instead of matching an empty string
+(`md5sum` on Linux prints the same hash first):
 
 ```sh
-test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = \
-     "$(md5 -q path/to/gascity/assets/scripts/codex-infisical-shim.sh)"
+git -C path/to/gascity-packs show <pin>:gascity/assets/scripts/codex-infisical-shim.sh | md5 -q
+test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = <that md5>
 ```
 
 `gascity/tests/test_codex_infisical_shim.py` holds the contract: fail-open
-with token.sh absent, present and failing; argv intact; PATH pruned through
-symlinked and relative aliases; the self-exec refusals; the settings file
-never evaluated.
+with the helper absent, present, failing, exiting, printing or rewriting
+argv; only the token crosses over; argv intact; PATH pruned through
+symlinked and relative aliases with empty entries kept; the self-exec
+refusals, with no utility on PATH; the settings file never evaluated; the
+install recipe above run from a fresh directory and the md5 check failing on
+a missing file.
 
 ## Build Methodology Contract
 

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -228,7 +228,9 @@ directory), the target is the executable file `type -P` finds (an exported
 function or alias named `codex` is ignored) and that checked path is what
 runs, and no codex left on PATH is an error (exit 127), never a loop.
 Inherited shell options reach codex as they came: xtrace is off while the
-token is handled and back on for the exec, noglob is left as found.
+token is handled and back on for the exec with the shim's own trace lines
+discarded (a `PS4` that expands the token prints nothing), noglob and
+errexit are left as found.
 
 Install it as the city's shim, in its own directory (gc does not sync a
 pack's `assets/scripts` anywhere), with the per-city settings in a

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -204,6 +204,75 @@ Default formula routes use these qualified targets: `gc.run-operator`,
 `gc.implementation-worker`, `gc.gap-analyst`, `gc.implementation-reviewer`,
 and `gc.publisher`.
 
+## Codex provider shim
+
+A Codex session has no memory that tells it how to mint a secret-store token,
+so a city that gives its Codex role agents an Infisical machine identity mints
+the token at session start. An agent's `env` map is static and `pre_start`
+runs in its own process; the one city-side place a freshly minted value can
+enter the session environment is a provider `command` wrapper. This pack
+ships that wrapper as `assets/scripts/codex-infisical-shim.sh`: it sources
+`$HOME/.config/infisical-agent/token.sh` fail-open when `INFISICAL_TOKEN` is
+unset (a missing file is silent, a failing login leaves the token unset and
+prints one WARN, the session starts either way), then execs the real codex
+with argv intact. It never execs itself: every PATH entry that resolves to
+its own directory is removed first, and no codex left on PATH is an error
+(exit 127), never a loop. The token is never echoed.
+
+Install it as the city's shim, in its own directory (gc does not sync a
+pack's `assets/scripts` anywhere), with the per-city settings in a
+`codex.env` beside it; the environment overrides the file, the file is plain
+`KEY=VALUE` lines and never evaluated:
+
+```sh
+install -m 0755 path/to/gascity/assets/scripts/codex-infisical-shim.sh \
+  "$CITY/.gc/shims/codex-astra/codex"
+cat > "$CITY/.gc/shims/codex-astra/codex.env" <<'EOT'
+CODEX_SHIM_PATH_PREPEND=/abs/path/to/city/.gc/shims/toolchain
+CODEX_SHIM_EXEC=npx -y @openai/codex@0.153.3
+EOT
+```
+
+`CODEX_SHIM_PATH_PREPEND` puts the city's toolchain wrappers first on PATH for
+the session and every child process, git hooks included; `CODEX_SHIM_EXEC` is
+the command line that runs the real codex when it is a pinned build rather
+than the `codex` on PATH. Both are optional.
+
+The provider runs the shim and the role agents select the provider. In
+`city.toml`, a provider over `builtin:codex` names the shim as its `command`
+and, because codex resumes by subcommand, its `resume_command`; each Codex
+role agent (an `agents/<name>/agent.toml`, one per rig) sets
+`provider = "codex-astra"` and carries the project id the Infisical CLI needs
+under a machine identity as `[env] INFISICAL_PROJECT_ID` (an id, not a
+secret):
+
+```toml
+# city.toml
+[providers.codex-astra]
+base = "builtin:codex"
+command = "/abs/path/to/city/.gc/shims/codex-astra/codex"
+resume_command = "/abs/path/to/city/.gc/shims/codex-astra/codex resume {{.SessionKey}}"
+
+# agents/implementation-worker-codex/agent.toml
+provider = "codex-astra"
+[env]
+INFISICAL_PROJECT_ID = "<project id>"
+```
+
+The installed copy is city runtime state; the file here is its source of
+record. A city verifies at each wake that the installed shim is this file,
+by md5 against the pack checkout at the installed pin:
+
+```sh
+test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = \
+     "$(md5 -q path/to/gascity/assets/scripts/codex-infisical-shim.sh)"
+```
+
+`gascity/tests/test_codex_infisical_shim.py` holds the contract: fail-open
+with token.sh absent, present and failing; argv intact; PATH pruned through
+symlinked and relative aliases; the self-exec refusals; the settings file
+never evaluated.
+
 ## Build Methodology Contract
 
 `build-base` is the virtual full-lifecycle workflow contract. It defines the

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -213,15 +213,18 @@ runs in its own process; the one city-side place a freshly minted value can
 enter the session environment is a provider `command` wrapper. This pack
 ships that wrapper as `assets/scripts/codex-infisical-shim.sh`: when
 `INFISICAL_TOKEN` is unset or empty it sources
-`$HOME/.config/infisical-agent/token.sh` fail-open, in a subshell with the
-helper's output discarded, and carries over exactly one value, the token the
-helper exported (a missing file is silent, a failing helper leaves the token
-unset and prints one WARN, an `exit` or a `set --` in the helper cannot reach
-the shim, the session starts either way); then it execs the real codex with
-argv intact. It never execs itself: it locates itself with shell builtins
-only and refuses to run when it cannot, every PATH entry that resolves to its
-own directory is removed first, and no codex left on PATH is an error (exit
-127), never a loop. Nothing the helper prints reaches the session output.
+`$HOME/.config/infisical-agent/token.sh` fail-open, in a subshell whose
+stdout and stderr are `/dev/null` for its whole lifetime, and carries over
+exactly one value, the token the helper exported (a missing file is silent, a
+failing helper leaves the token unset and prints one WARN, an `exit`, a
+`set --`, a trace or an EXIT trap in the helper cannot reach the shim or the
+session output, the session starts either way); then it execs the real codex
+with argv intact. It never execs itself: it locates itself with shell
+builtins only and refuses to run when it cannot, every PATH entry that
+resolves to its own directory is removed first (empty entries kept; when
+nothing survives, PATH becomes `/dev/null`, never the empty string bash reads
+as the current directory), and no codex left on PATH is an error (exit 127),
+never a loop.
 
 Install it as the city's shim, in its own directory (gc does not sync a
 pack's `assets/scripts` anywhere), with the per-city settings in a
@@ -268,22 +271,25 @@ INFISICAL_PROJECT_ID = "<project id>"
 The installed copy is city runtime state; the file here is its source of
 record. A city verifies at each wake that the installed shim is this file at
 the installed pin. Record the canonical md5 once, from the pack checkout at
-that pin, and compare the installed file to the literal, so a missing file or
-a missing md5 tool fails the check instead of matching an empty string
-(`md5sum` on Linux prints the same hash first):
+that pin (the extraction must succeed before anything is hashed, so a bad pin
+records nothing rather than the hash of empty input), and compare the
+installed file to the literal, so a missing file or a missing md5 tool fails
+the check instead of matching an empty string (`md5sum` on Linux prints the
+same hash first):
 
 ```sh
-git -C path/to/gascity-packs show <pin>:gascity/assets/scripts/codex-infisical-shim.sh | md5 -q
+canonical=$(mktemp) && git -C path/to/gascity-packs show <pin>:gascity/assets/scripts/codex-infisical-shim.sh > "$canonical" && md5 -q "$canonical"
 test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = <that md5>
 ```
 
 `gascity/tests/test_codex_infisical_shim.py` holds the contract: fail-open
-with the helper absent, present, failing, exiting, printing or rewriting
-argv; only the token crosses over; argv intact; PATH pruned through
-symlinked and relative aliases with empty entries kept; the self-exec
-refusals, with no utility on PATH; the settings file never evaluated; the
-install recipe above run from a fresh directory and the md5 check failing on
-a missing file.
+with the helper absent, present, failing, exiting, tracing, trapping,
+printing or rewriting argv; only the token crosses over; argv intact; PATH
+pruned through symlinked and relative aliases with empty entries kept and
+never emptied; the self-exec refusals, with no utility on PATH and under
+CDPATH; the settings file never evaluated; the install recipe above run from
+a fresh directory, the md5 recording refusing a bad pin and the check failing
+on a missing file.
 
 ## Build Methodology Contract
 

--- a/gascity/README.md
+++ b/gascity/README.md
@@ -229,8 +229,9 @@ function or alias named `codex` is ignored) and that checked path is what
 runs, and no codex left on PATH is an error (exit 127), never a loop.
 Inherited shell options reach codex as they came: xtrace is off while the
 token is handled and back on for the exec with the shim's own trace lines
-discarded (a `PS4` that expands the token prints nothing), noglob and
-errexit are left as found.
+discarded on stdout and stderr alike (a `PS4` that expands the token prints
+nothing, whichever of the two `BASH_XTRACEFD` names), noglob and errexit
+are left as found.
 
 Install it as the city's shim, in its own directory (gc does not sync a
 pack's `assets/scripts` anywhere), with the per-city settings in a

--- a/gascity/assets/scripts/codex-infisical-shim.sh
+++ b/gascity/assets/scripts/codex-infisical-shim.sh
@@ -77,9 +77,11 @@
 #     cis_ prefix, are initialized before use (an inherited cis_ export is not
 #     configuration) and are unset before the exec, so an inherited export of
 #     an ordinary name is never overwritten. Inherited shell options are kept:
-#     xtrace is switched off before the token is touched and back on just
-#     before the exec (so SHELLOPTS reaches the child as it came), noglob is
-#     left as found.
+#     xtrace is switched off before the token is touched and back on for the
+#     exec (so SHELLOPTS reaches the child as it came) with the shim's own
+#     trace lines discarded, so a PS4 that expands the token prints nothing;
+#     noglob and errexit are left as found (the lookups cannot trip errexit;
+#     the 127 diagnostics still print).
 #
 # Relation to the copy this was extracted from (citadel, gp-e8r6, 2026-09-10):
 # same fail-open semantics and the same helper; the PATH prepend and the pinned
@@ -89,8 +91,11 @@
 # and the self-exec guard are new; the WARN prefix names this script.
 
 # Inherited tracing (SHELLOPTS=xtrace) would print the token: off until the exec.
-cis_xtrace=0
-case $- in *x*) cis_xtrace=1; set +x ;; esac
+# The group's stderr is /dev/null so the lines that switch it off trace nowhere.
+{
+  cis_xtrace=0
+  case $- in *x*) cis_xtrace=1; set +x ;; esac
+} 2>/dev/null
 cis_noglob=0
 case $- in *f*) cis_noglob=1 ;; esac
 
@@ -103,7 +108,7 @@ cis_die() {
 cis_self=$0
 case $cis_self in
   */*) ;;
-  *) cis_self=$(builtin type -P -- "$cis_self" 2>/dev/null) ;;
+  *) cis_self=$(builtin type -P -- "$cis_self" 2>/dev/null || :) ;;
 esac
 [ -n "$cis_self" ] || cis_die "cannot locate the shim itself from \$0='$0'; refusing to exec"
 cis_self_dir=${cis_self%/*}
@@ -198,19 +203,20 @@ else
   set -- codex "$@"
 fi
 # The executable file, never a function, alias or builtin of that name.
-cis_target=$(builtin type -P -- "$1" 2>/dev/null)
+cis_target=$(builtin type -P -- "$1" 2>/dev/null || :)
 [ -n "$cis_target" ] \
   || cis_die "no '$1' on PATH after removing the shim's directory ($cis_self_dir); set CODEX_SHIM_EXEC or install codex"
 if [ "$cis_target" -ef "$cis_self_file" ]; then
   cis_die "'$1' resolves to the shim itself ($cis_self_file); refusing to exec"
 fi
-cis_argv0=$1
-shift
-set -- "$cis_target" "$@"
-cis_restore_xtrace=$cis_xtrace
+# $1 = restore xtrace, $2 = the checked file, $3 = argv[0], the rest = codex's argv.
+set -- "$cis_xtrace" "$cis_target" "$@"
 unset cis_self cis_self_dir cis_self_file cis_sidecar cis_line cis_key cis_val cis_prepend cis_exec \
-  cis_rest cis_pruned cis_first cis_entry cis_more cis_token_sh cis_words cis_target cis_xtrace cis_noglob
+  cis_rest cis_pruned cis_first cis_entry cis_more cis_token_sh cis_token cis_words cis_target cis_xtrace cis_noglob
 unset -f cis_die
-[ "$cis_restore_xtrace" = 1 ] && set -x
-unset cis_restore_xtrace
-exec -a "$cis_argv0" "$@"
+if [ "$1" = 1 ]; then
+  # Tracing back on for the child; the shim's own two trace lines go to
+  # /dev/null while the child gets the real stderr back (saved on fd 3).
+  { set -x; exec -a "$3" "$2" "${@:4}" 2>&3 3>&-; } 3>&2 2>/dev/null
+fi
+exec -a "$3" "$2" "${@:4}"

--- a/gascity/assets/scripts/codex-infisical-shim.sh
+++ b/gascity/assets/scripts/codex-infisical-shim.sh
@@ -29,9 +29,10 @@
 #   INFISICAL_PROJECT_ID = "<project id, not a secret>"
 #
 #   # verify the installed copy is this file at the installed pin (a wake
-#   # checks it): record the canonical md5 once, compare the installed file to
-#   # that literal, so a missing file or a missing md5 tool fails the check.
-#   git -C path/to/gascity-packs show <pin>:gascity/assets/scripts/codex-infisical-shim.sh | md5 -q
+#   # checks it): record the canonical md5 once (the extraction must succeed
+#   # before anything is hashed), compare the installed file to that literal,
+#   # so a missing file, a bad pin or a missing md5 tool fails the check.
+#   canonical=$(mktemp) && git -C path/to/gascity-packs show <pin>:gascity/assets/scripts/codex-infisical-shim.sh > "$canonical" && md5 -q "$canonical"
 #   test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = <that md5>
 #
 # Inputs (a variable present in the environment, even empty, wins over
@@ -50,24 +51,29 @@
 # Contract:
 #   * Fail-open token. If INFISICAL_TOKEN is unset or empty and
 #     $HOME/.config/infisical-agent/token.sh is readable, the shim sources it in
-#     a subshell with its output discarded and carries over exactly one value,
-#     the INFISICAL_TOKEN it exported; the helper's other exports, an `exit` in
-#     it, or a `set --` in it cannot reach the shim. A missing token.sh is
-#     silent; a helper that fails or leaves the token empty leaves
-#     INFISICAL_TOKEN unset and prints one WARN on stderr. The exec happens
-#     either way. Nothing the helper prints reaches the session output.
+#     a subshell whose stdout and stderr are /dev/null for its whole lifetime
+#     (traces and EXIT traps included) and carries over exactly one value, the
+#     INFISICAL_TOKEN it exported, through a dedicated descriptor; the helper's
+#     other exports, an `exit` in it, or a `set --` in it cannot reach the shim.
+#     A missing token.sh is silent; a helper that fails or leaves the token
+#     empty leaves INFISICAL_TOKEN unset and prints one WARN on stderr. The
+#     exec happens either way. Nothing the helper prints reaches the session
+#     output.
 #   * A non-empty INFISICAL_TOKEN is kept as is; token.sh is not sourced.
 #   * argv reaches the real codex intact, in order, nothing added or dropped.
 #   * The shim never execs itself. It locates itself with shell builtins only
 #     and refuses to run (exit 127) when it cannot; every PATH entry that
 #     resolves to its own directory is removed before the lookup (the child's
-#     PATH is the pruned one, empty entries kept), and an exec target that is
-#     the shim file itself is refused. No codex left on PATH is an error (exit
-#     127), never a loop. No external utility is needed for any of this.
+#     PATH is the pruned one, empty entries kept; when nothing survives PATH
+#     becomes /dev/null, never the empty string bash reads as the current
+#     directory), and an exec target that is the shim file itself is refused.
+#     No codex left on PATH is an error (exit 127), never a loop. No external
+#     utility is needed for any of this, and CDPATH has no effect on it.
 #   * Nothing else in the environment is changed: PATH (prepend + prune) and
 #     INFISICAL_TOKEN are the only writes; the shim's own variables carry the
-#     cis_ prefix and are unset before the exec, so an inherited export of an
-#     ordinary name is never overwritten.
+#     cis_ prefix, are initialized before use (an inherited cis_ export is not
+#     configuration) and are unset before the exec, so an inherited export of
+#     an ordinary name is never overwritten.
 #
 # Relation to the copy this was extracted from (citadel, gp-e8r6, 2026-09-10):
 # same fail-open semantics and the same helper; the PATH prepend and the pinned
@@ -91,13 +97,15 @@ esac
 cis_self_dir=${cis_self%/*}
 [ "$cis_self_dir" != "$cis_self" ] || cis_self_dir=.
 [ -n "$cis_self_dir" ] || cis_self_dir=/
-cis_self_dir=$(cd -- "$cis_self_dir" 2>/dev/null && pwd -P) \
+cis_self_dir=$(unset CDPATH; cd -- "$cis_self_dir" >/dev/null 2>&1 && pwd -P) \
   || cis_die "cannot resolve the shim's directory from '$cis_self'; refusing to exec"
 cis_self_file="$cis_self_dir/${cis_self##*/}"
 [ -e "$cis_self_file" ] || cis_die "the shim does not exist at '$cis_self_file'; refusing to exec"
 
 # --- settings: environment (presence wins), then <shim>.env ----------------------
 cis_sidecar="$cis_self_file.env"
+cis_prepend=
+cis_exec=
 if [ -r "$cis_sidecar" ]; then
   while IFS= read -r cis_line || [ -n "$cis_line" ]; do
     case $cis_line in ''|'#'*) continue ;; esac
@@ -133,7 +141,7 @@ while :; do
     *:*) cis_entry=${cis_rest%%:*}; cis_rest=${cis_rest#*:}; cis_more=1 ;;
     *) cis_entry=$cis_rest; cis_more=0 ;;
   esac
-  cis_phys=$(cd -- "${cis_entry:-.}" 2>/dev/null && pwd -P) || cis_phys=
+  cis_phys=$(unset CDPATH; cd -- "${cis_entry:-.}" >/dev/null 2>&1 && pwd -P) || cis_phys=
   if [ "$cis_phys" != "$cis_self_dir" ]; then
     if [ "$cis_first" = 1 ]; then
       cis_pruned=$cis_entry
@@ -144,14 +152,20 @@ while :; do
   fi
   [ "$cis_more" = 1 ] || break
 done
+if [ "$cis_first" = 1 ]; then
+  cis_pruned=/dev/null
+fi
 PATH=$cis_pruned
 export PATH
 
 # --- Infisical machine identity, fail-open, helper isolated in a subshell --------
 cis_token_sh="${HOME:-}/.config/infisical-agent/token.sh"
 if [ -z "${INFISICAL_TOKEN:-}" ] && [ -n "${HOME:-}" ] && [ -r "$cis_token_sh" ]; then
+  # The subshell's stdout and stderr are /dev/null for its whole lifetime, so a
+  # trace or an EXIT trap in the helper cannot print; the token leaves through
+  # descriptor 3, the capture.
   # shellcheck disable=SC1090
-  if cis_token=$(. "$cis_token_sh" >/dev/null 2>&1 && printf '%s' "${INFISICAL_TOKEN-}") \
+  if cis_token=$( ( exec 3>&1 >/dev/null 2>&1; . "$cis_token_sh" && set +x && builtin printf '%s' "${INFISICAL_TOKEN-}" >&3 ) ) \
      && [ -n "$cis_token" ]; then
     INFISICAL_TOKEN=$cis_token
     export INFISICAL_TOKEN

--- a/gascity/assets/scripts/codex-infisical-shim.sh
+++ b/gascity/assets/scripts/codex-infisical-shim.sh
@@ -79,7 +79,8 @@
 #     an ordinary name is never overwritten. Inherited shell options are kept:
 #     xtrace is switched off before the token is touched and back on for the
 #     exec (so SHELLOPTS reaches the child as it came) with the shim's own
-#     trace lines discarded, so a PS4 that expands the token prints nothing;
+#     trace lines discarded on stdout and stderr alike (BASH_XTRACEFD=1 or 2
+#     included), so a PS4 that expands the token prints nothing;
 #     noglob and errexit are left as found (the lookups cannot trip errexit;
 #     the 127 diagnostics still print).
 #
@@ -91,11 +92,12 @@
 # and the self-exec guard are new; the WARN prefix names this script.
 
 # Inherited tracing (SHELLOPTS=xtrace) would print the token: off until the exec.
-# The group's stderr is /dev/null so the lines that switch it off trace nowhere.
+# The group's stdout and stderr are /dev/null so the lines that switch it off
+# trace nowhere, whichever of the two BASH_XTRACEFD names.
 {
   cis_xtrace=0
   case $- in *x*) cis_xtrace=1; set +x ;; esac
-} 2>/dev/null
+} >/dev/null 2>&1
 cis_noglob=0
 case $- in *f*) cis_noglob=1 ;; esac
 
@@ -216,7 +218,8 @@ unset cis_self cis_self_dir cis_self_file cis_sidecar cis_line cis_key cis_val c
 unset -f cis_die
 if [ "$1" = 1 ]; then
   # Tracing back on for the child; the shim's own two trace lines go to
-  # /dev/null while the child gets the real stderr back (saved on fd 3).
-  { set -x; exec -a "$3" "$2" "${@:4}" 2>&3 3>&-; } 3>&2 2>/dev/null
+  # /dev/null on stdout and stderr alike, while the child gets the real
+  # descriptors back (stderr saved on fd 3, stdout on fd 4).
+  { set -x; exec -a "$3" "$2" "${@:4}" >&4 2>&3 3>&- 4>&-; } 3>&2 4>&1 >/dev/null 2>&1
 fi
 exec -a "$3" "$2" "${@:4}"

--- a/gascity/assets/scripts/codex-infisical-shim.sh
+++ b/gascity/assets/scripts/codex-infisical-shim.sh
@@ -62,18 +62,24 @@
 #   * A non-empty INFISICAL_TOKEN is kept as is; token.sh is not sourced.
 #   * argv reaches the real codex intact, in order, nothing added or dropped.
 #   * The shim never execs itself. It locates itself with shell builtins only
-#     and refuses to run (exit 127) when it cannot; every PATH entry that
-#     resolves to its own directory is removed before the lookup (the child's
-#     PATH is the pruned one, empty entries kept; when nothing survives PATH
-#     becomes /dev/null, never the empty string bash reads as the current
-#     directory), and an exec target that is the shim file itself is refused.
-#     No codex left on PATH is an error (exit 127), never a loop. No external
-#     utility is needed for any of this, and CDPATH has no effect on it.
+#     and refuses to run (exit 127) when it cannot; every PATH entry that is
+#     its own directory (same inode, so symlinked, relative or doubled-slash
+#     spellings count) is removed before the lookup (the child's PATH is the
+#     pruned one, empty entries kept; when nothing survives PATH becomes
+#     /dev/null, never the empty string bash reads as the current directory).
+#     The exec target is the executable FILE `type -P` finds (an exported
+#     function or alias of the same name is ignored), it is refused when it is
+#     the shim file itself, and that checked path is what runs, with argv[0]
+#     kept. No codex left on PATH is an error (exit 127), never a loop. No
+#     external utility is needed for any of this, and CDPATH has no effect.
 #   * Nothing else in the environment is changed: PATH (prepend + prune) and
 #     INFISICAL_TOKEN are the only writes; the shim's own variables carry the
 #     cis_ prefix, are initialized before use (an inherited cis_ export is not
 #     configuration) and are unset before the exec, so an inherited export of
-#     an ordinary name is never overwritten.
+#     an ordinary name is never overwritten. Inherited shell options are kept:
+#     xtrace is switched off before the token is touched and back on just
+#     before the exec (so SHELLOPTS reaches the child as it came), noglob is
+#     left as found.
 #
 # Relation to the copy this was extracted from (citadel, gp-e8r6, 2026-09-10):
 # same fail-open semantics and the same helper; the PATH prepend and the pinned
@@ -81,6 +87,12 @@
 # installs on any city; the helper now runs in a subshell and only its token
 # crosses over (the original sourced it in-process); the default exec target
 # and the self-exec guard are new; the WARN prefix names this script.
+
+# Inherited tracing (SHELLOPTS=xtrace) would print the token: off until the exec.
+cis_xtrace=0
+case $- in *x*) cis_xtrace=1; set +x ;; esac
+cis_noglob=0
+case $- in *f*) cis_noglob=1 ;; esac
 
 cis_die() {
   echo "codex-infisical-shim: ERROR $1" >&2
@@ -91,13 +103,13 @@ cis_die() {
 cis_self=$0
 case $cis_self in
   */*) ;;
-  *) cis_self=$(command -v -- "$cis_self" 2>/dev/null) ;;
+  *) cis_self=$(builtin type -P -- "$cis_self" 2>/dev/null) ;;
 esac
 [ -n "$cis_self" ] || cis_die "cannot locate the shim itself from \$0='$0'; refusing to exec"
 cis_self_dir=${cis_self%/*}
 [ "$cis_self_dir" != "$cis_self" ] || cis_self_dir=.
 [ -n "$cis_self_dir" ] || cis_self_dir=/
-cis_self_dir=$(unset CDPATH; cd -- "$cis_self_dir" >/dev/null 2>&1 && pwd -P) \
+cis_self_dir=$(unset CDPATH; cd -P -- "$cis_self_dir" >/dev/null 2>&1 && pwd -P) \
   || cis_die "cannot resolve the shim's directory from '$cis_self'; refusing to exec"
 cis_self_file="$cis_self_dir/${cis_self##*/}"
 [ -e "$cis_self_file" ] || cis_die "the shim does not exist at '$cis_self_file'; refusing to exec"
@@ -141,8 +153,7 @@ while :; do
     *:*) cis_entry=${cis_rest%%:*}; cis_rest=${cis_rest#*:}; cis_more=1 ;;
     *) cis_entry=$cis_rest; cis_more=0 ;;
   esac
-  cis_phys=$(unset CDPATH; cd -- "${cis_entry:-.}" >/dev/null 2>&1 && pwd -P) || cis_phys=
-  if [ "$cis_phys" != "$cis_self_dir" ]; then
+  if ! [ "${cis_entry:-.}" -ef "$cis_self_dir" ]; then
     if [ "$cis_first" = 1 ]; then
       cis_pruned=$cis_entry
       cis_first=0
@@ -180,19 +191,26 @@ fi
 set -f
 # shellcheck disable=SC2206
 cis_words=(${cis_exec:-})
-set +f
+[ "$cis_noglob" = 1 ] || set +f
 if [ "${#cis_words[@]}" -gt 0 ]; then
   set -- "${cis_words[@]}" "$@"
 else
   set -- codex "$@"
 fi
-cis_target=$(command -v -- "$1" 2>/dev/null)
+# The executable file, never a function, alias or builtin of that name.
+cis_target=$(builtin type -P -- "$1" 2>/dev/null)
 [ -n "$cis_target" ] \
   || cis_die "no '$1' on PATH after removing the shim's directory ($cis_self_dir); set CODEX_SHIM_EXEC or install codex"
 if [ "$cis_target" -ef "$cis_self_file" ]; then
   cis_die "'$1' resolves to the shim itself ($cis_self_file); refusing to exec"
 fi
+cis_argv0=$1
+shift
+set -- "$cis_target" "$@"
+cis_restore_xtrace=$cis_xtrace
 unset cis_self cis_self_dir cis_self_file cis_sidecar cis_line cis_key cis_val cis_prepend cis_exec \
-  cis_rest cis_pruned cis_first cis_entry cis_more cis_phys cis_token_sh cis_words cis_target
+  cis_rest cis_pruned cis_first cis_entry cis_more cis_token_sh cis_words cis_target cis_xtrace cis_noglob
 unset -f cis_die
-exec "$@"
+[ "$cis_restore_xtrace" = 1 ] && set -x
+unset cis_restore_xtrace
+exec -a "$cis_argv0" "$@"

--- a/gascity/assets/scripts/codex-infisical-shim.sh
+++ b/gascity/assets/scripts/codex-infisical-shim.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# codex-infisical-shim.sh — start a Codex session with an Infisical machine
+# identity token in its environment, then exec the real codex.
+#
+# Built to be a Gas City provider `command`. An agent's `env` map is static and
+# `pre_start` runs in its own process, so a provider command wrapper is the one
+# city-side place a freshly minted value can enter the session environment.
+#
+# INSTALL (the city half; this pack does not sync assets/scripts anywhere):
+#
+#   install -m 0755 path/to/gascity/assets/scripts/codex-infisical-shim.sh \
+#     "$CITY/.gc/shims/codex-astra/codex"
+#   # optional per-city settings, beside the shim, named <shim>.env:
+#   cat > "$CITY/.gc/shims/codex-astra/codex.env" <<'EOF'
+#   CODEX_SHIM_PATH_PREPEND=/abs/path/to/city/.gc/shims/toolchain
+#   CODEX_SHIM_EXEC=npx -y @openai/codex@0.153.3
+#   EOF
+#
+#   # city.toml — the provider runs the shim; the role agents select it.
+#   [providers.codex-astra]
+#   base = "builtin:codex"
+#   command = "/abs/path/to/city/.gc/shims/codex-astra/codex"
+#   resume_command = "/abs/path/to/city/.gc/shims/codex-astra/codex resume {{.SessionKey}}"
+#
+#   # agents/<role>/agent.toml — one per rig
+#   provider = "codex-astra"
+#   [env]
+#   INFISICAL_PROJECT_ID = "<project id, not a secret>"
+#
+#   # verify the installed copy is this file (a wake checks the md5):
+#   test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = \
+#        "$(md5 -q path/to/gascity/assets/scripts/codex-infisical-shim.sh)"
+#
+# Inputs (environment wins over <shim>.env; the file is plain KEY=VALUE lines,
+# never evaluated by a shell; unknown keys are ignored with a WARN):
+#   CODEX_SHIM_PATH_PREPEND  colon-separated directories put first on PATH, so
+#                            the session and every child (git hooks included)
+#                            resolve the city's toolchain wrappers.
+#   CODEX_SHIM_EXEC          the command line that runs the real codex (split on
+#                            whitespace, no quoting), for a pinned build such as
+#                            `npx -y @openai/codex@0.153.3`. Default: `codex`
+#                            resolved from PATH with the shim's own directory
+#                            removed.
+#   HOME                     token.sh is read from $HOME/.config/infisical-agent/.
+#
+# Contract:
+#   * Fail-open token. If INFISICAL_TOKEN is unset and
+#     $HOME/.config/infisical-agent/token.sh is readable, the shim sources it
+#     (it exports INFISICAL_TOKEN from the universal-auth credentials and unsets
+#     the client id/secret again). A missing token.sh is silent; a failing one
+#     leaves INFISICAL_TOKEN unset and prints one WARN on stderr. The exec
+#     happens either way. The token is never echoed.
+#   * A set INFISICAL_TOKEN is kept as is; token.sh is not sourced.
+#   * argv reaches the real codex intact, in order, nothing added or dropped.
+#   * The shim never execs itself. Every PATH entry that resolves to the shim's
+#     own directory is removed before the lookup (the child's PATH is the pruned
+#     one), and an exec target that is the shim file itself is refused. No
+#     codex left on PATH is an error (exit 127), never a loop.
+#   * Nothing else in the environment is changed: PATH (prepend + prune) and
+#     INFISICAL_TOKEN are the only writes.
+#
+# Relation to the copy this was extracted from (citadel, gp-e8r6, 2026-09-10):
+# same token block and fail-open semantics; the PATH prepend and the pinned
+# `npx` command line moved from hardcoded values into <shim>.env so one file
+# installs on any city; the default exec target and the self-exec guard are new;
+# the WARN prefix names this script.
+
+self_path=$0
+case $self_path in
+  */*) ;;
+  *) self_path=$(command -v -- "$self_path" 2>/dev/null || printf '%s' "$self_path") ;;
+esac
+self_dir=$(cd -- "$(dirname -- "$self_path")" 2>/dev/null && pwd -P)
+self_file="$self_dir/$(basename -- "$self_path")"
+
+# --- settings: environment, then <shim>.env ------------------------------------
+sidecar="$self_file.env"
+if [ -r "$sidecar" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    case $line in ''|'#'*) continue ;; esac
+    case $line in *=*) ;; *) echo "codex-infisical-shim: WARN ignoring line without '=' in $sidecar" >&2; continue ;; esac
+    key=${line%%=*}
+    val=${line#*=}
+    case $val in
+      \"*\") val=${val#\"}; val=${val%\"} ;;
+      \'*\') val=${val#\'}; val=${val%\'} ;;
+    esac
+    case $key in
+      CODEX_SHIM_PATH_PREPEND) [ -n "${CODEX_SHIM_PATH_PREPEND:-}" ] || CODEX_SHIM_PATH_PREPEND=$val ;;
+      CODEX_SHIM_EXEC) [ -n "${CODEX_SHIM_EXEC:-}" ] || CODEX_SHIM_EXEC=$val ;;
+      *) echo "codex-infisical-shim: WARN ignoring unknown key $key in $sidecar" >&2 ;;
+    esac
+  done < "$sidecar"
+fi
+
+# --- PATH: prepend the city's toolchain, then remove the shim's own directory ---
+if [ -n "${CODEX_SHIM_PATH_PREPEND:-}" ]; then
+  PATH="$CODEX_SHIM_PATH_PREPEND:$PATH"
+fi
+pruned=
+old_ifs=$IFS
+set -f
+IFS=:
+for entry in $PATH; do
+  phys=$(cd -- "${entry:-.}" 2>/dev/null && pwd -P) || phys=
+  if [ -n "$self_dir" ] && [ "$phys" = "$self_dir" ]; then
+    continue
+  fi
+  pruned="${pruned:+$pruned:}$entry"
+done
+IFS=$old_ifs
+set +f
+PATH=$pruned
+export PATH
+
+# --- Infisical machine identity, fail-open -------------------------------------
+token_sh="${HOME:-}/.config/infisical-agent/token.sh"
+if [ -z "${INFISICAL_TOKEN:-}" ] && [ -n "${HOME:-}" ] && [ -r "$token_sh" ]; then
+  # shellcheck disable=SC1090
+  . "$token_sh" 2>/dev/null \
+    || { unset INFISICAL_TOKEN; echo "codex-infisical-shim: WARN Infisical machine-identity login failed; INFISICAL_TOKEN unset" >&2; }
+fi
+
+# --- exec the real codex --------------------------------------------------------
+if [ -n "${CODEX_SHIM_EXEC:-}" ]; then
+  set -f
+  # shellcheck disable=SC2086
+  set -- $CODEX_SHIM_EXEC "$@"
+  set +f
+else
+  set -- codex "$@"
+fi
+target=$(command -v -- "$1" 2>/dev/null)
+if [ -z "$target" ]; then
+  echo "codex-infisical-shim: ERROR no '$1' on PATH after removing the shim's directory ($self_dir); set CODEX_SHIM_EXEC or install codex" >&2
+  exit 127
+fi
+if [ "$target" -ef "$self_file" ]; then
+  echo "codex-infisical-shim: ERROR '$1' resolves to the shim itself ($self_file); refusing to exec" >&2
+  exit 127
+fi
+exec "$@"

--- a/gascity/assets/scripts/codex-infisical-shim.sh
+++ b/gascity/assets/scripts/codex-infisical-shim.sh
@@ -8,6 +8,7 @@
 #
 # INSTALL (the city half; this pack does not sync assets/scripts anywhere):
 #
+#   mkdir -p "$CITY/.gc/shims/codex-astra"
 #   install -m 0755 path/to/gascity/assets/scripts/codex-infisical-shim.sh \
 #     "$CITY/.gc/shims/codex-astra/codex"
 #   # optional per-city settings, beside the shim, named <shim>.env:
@@ -27,12 +28,15 @@
 #   [env]
 #   INFISICAL_PROJECT_ID = "<project id, not a secret>"
 #
-#   # verify the installed copy is this file (a wake checks the md5):
-#   test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = \
-#        "$(md5 -q path/to/gascity/assets/scripts/codex-infisical-shim.sh)"
+#   # verify the installed copy is this file at the installed pin (a wake
+#   # checks it): record the canonical md5 once, compare the installed file to
+#   # that literal, so a missing file or a missing md5 tool fails the check.
+#   git -C path/to/gascity-packs show <pin>:gascity/assets/scripts/codex-infisical-shim.sh | md5 -q
+#   test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = <that md5>
 #
-# Inputs (environment wins over <shim>.env; the file is plain KEY=VALUE lines,
-# never evaluated by a shell; unknown keys are ignored with a WARN):
+# Inputs (a variable present in the environment, even empty, wins over
+# <shim>.env; the file is plain KEY=VALUE lines, never evaluated by a shell;
+# unknown keys are ignored with a WARN; a blank value means "not set"):
 #   CODEX_SHIM_PATH_PREPEND  colon-separated directories put first on PATH, so
 #                            the session and every child (git hooks included)
 #                            resolve the city's toolchain wrappers.
@@ -44,99 +48,137 @@
 #   HOME                     token.sh is read from $HOME/.config/infisical-agent/.
 #
 # Contract:
-#   * Fail-open token. If INFISICAL_TOKEN is unset and
-#     $HOME/.config/infisical-agent/token.sh is readable, the shim sources it
-#     (it exports INFISICAL_TOKEN from the universal-auth credentials and unsets
-#     the client id/secret again). A missing token.sh is silent; a failing one
-#     leaves INFISICAL_TOKEN unset and prints one WARN on stderr. The exec
-#     happens either way. The token is never echoed.
-#   * A set INFISICAL_TOKEN is kept as is; token.sh is not sourced.
+#   * Fail-open token. If INFISICAL_TOKEN is unset or empty and
+#     $HOME/.config/infisical-agent/token.sh is readable, the shim sources it in
+#     a subshell with its output discarded and carries over exactly one value,
+#     the INFISICAL_TOKEN it exported; the helper's other exports, an `exit` in
+#     it, or a `set --` in it cannot reach the shim. A missing token.sh is
+#     silent; a helper that fails or leaves the token empty leaves
+#     INFISICAL_TOKEN unset and prints one WARN on stderr. The exec happens
+#     either way. Nothing the helper prints reaches the session output.
+#   * A non-empty INFISICAL_TOKEN is kept as is; token.sh is not sourced.
 #   * argv reaches the real codex intact, in order, nothing added or dropped.
-#   * The shim never execs itself. Every PATH entry that resolves to the shim's
-#     own directory is removed before the lookup (the child's PATH is the pruned
-#     one), and an exec target that is the shim file itself is refused. No
-#     codex left on PATH is an error (exit 127), never a loop.
+#   * The shim never execs itself. It locates itself with shell builtins only
+#     and refuses to run (exit 127) when it cannot; every PATH entry that
+#     resolves to its own directory is removed before the lookup (the child's
+#     PATH is the pruned one, empty entries kept), and an exec target that is
+#     the shim file itself is refused. No codex left on PATH is an error (exit
+#     127), never a loop. No external utility is needed for any of this.
 #   * Nothing else in the environment is changed: PATH (prepend + prune) and
-#     INFISICAL_TOKEN are the only writes.
+#     INFISICAL_TOKEN are the only writes; the shim's own variables carry the
+#     cis_ prefix and are unset before the exec, so an inherited export of an
+#     ordinary name is never overwritten.
 #
 # Relation to the copy this was extracted from (citadel, gp-e8r6, 2026-09-10):
-# same token block and fail-open semantics; the PATH prepend and the pinned
+# same fail-open semantics and the same helper; the PATH prepend and the pinned
 # `npx` command line moved from hardcoded values into <shim>.env so one file
-# installs on any city; the default exec target and the self-exec guard are new;
-# the WARN prefix names this script.
+# installs on any city; the helper now runs in a subshell and only its token
+# crosses over (the original sourced it in-process); the default exec target
+# and the self-exec guard are new; the WARN prefix names this script.
 
-self_path=$0
-case $self_path in
+cis_die() {
+  echo "codex-infisical-shim: ERROR $1" >&2
+  exit 127
+}
+
+# --- locate self with builtins only ---------------------------------------------
+cis_self=$0
+case $cis_self in
   */*) ;;
-  *) self_path=$(command -v -- "$self_path" 2>/dev/null || printf '%s' "$self_path") ;;
+  *) cis_self=$(command -v -- "$cis_self" 2>/dev/null) ;;
 esac
-self_dir=$(cd -- "$(dirname -- "$self_path")" 2>/dev/null && pwd -P)
-self_file="$self_dir/$(basename -- "$self_path")"
+[ -n "$cis_self" ] || cis_die "cannot locate the shim itself from \$0='$0'; refusing to exec"
+cis_self_dir=${cis_self%/*}
+[ "$cis_self_dir" != "$cis_self" ] || cis_self_dir=.
+[ -n "$cis_self_dir" ] || cis_self_dir=/
+cis_self_dir=$(cd -- "$cis_self_dir" 2>/dev/null && pwd -P) \
+  || cis_die "cannot resolve the shim's directory from '$cis_self'; refusing to exec"
+cis_self_file="$cis_self_dir/${cis_self##*/}"
+[ -e "$cis_self_file" ] || cis_die "the shim does not exist at '$cis_self_file'; refusing to exec"
 
-# --- settings: environment, then <shim>.env ------------------------------------
-sidecar="$self_file.env"
-if [ -r "$sidecar" ]; then
-  while IFS= read -r line || [ -n "$line" ]; do
-    case $line in ''|'#'*) continue ;; esac
-    case $line in *=*) ;; *) echo "codex-infisical-shim: WARN ignoring line without '=' in $sidecar" >&2; continue ;; esac
-    key=${line%%=*}
-    val=${line#*=}
-    case $val in
-      \"*\") val=${val#\"}; val=${val%\"} ;;
-      \'*\') val=${val#\'}; val=${val%\'} ;;
+# --- settings: environment (presence wins), then <shim>.env ----------------------
+cis_sidecar="$cis_self_file.env"
+if [ -r "$cis_sidecar" ]; then
+  while IFS= read -r cis_line || [ -n "$cis_line" ]; do
+    case $cis_line in ''|'#'*) continue ;; esac
+    case $cis_line in
+      *=*) ;;
+      *) echo "codex-infisical-shim: WARN ignoring line without '=' in $cis_sidecar" >&2; continue ;;
     esac
-    case $key in
-      CODEX_SHIM_PATH_PREPEND) [ -n "${CODEX_SHIM_PATH_PREPEND:-}" ] || CODEX_SHIM_PATH_PREPEND=$val ;;
-      CODEX_SHIM_EXEC) [ -n "${CODEX_SHIM_EXEC:-}" ] || CODEX_SHIM_EXEC=$val ;;
-      *) echo "codex-infisical-shim: WARN ignoring unknown key $key in $sidecar" >&2 ;;
+    cis_key=${cis_line%%=*}
+    cis_val=${cis_line#*=}
+    case $cis_val in
+      \"*\") cis_val=${cis_val#\"}; cis_val=${cis_val%\"} ;;
+      \'*\') cis_val=${cis_val#\'}; cis_val=${cis_val%\'} ;;
     esac
-  done < "$sidecar"
+    case $cis_key in
+      CODEX_SHIM_PATH_PREPEND) [ -n "${CODEX_SHIM_PATH_PREPEND+x}" ] || cis_prepend=$cis_val ;;
+      CODEX_SHIM_EXEC) [ -n "${CODEX_SHIM_EXEC+x}" ] || cis_exec=$cis_val ;;
+      *) echo "codex-infisical-shim: WARN ignoring unknown key $cis_key in $cis_sidecar" >&2 ;;
+    esac
+  done < "$cis_sidecar"
 fi
+[ -z "${CODEX_SHIM_PATH_PREPEND+x}" ] || cis_prepend=$CODEX_SHIM_PATH_PREPEND
+[ -z "${CODEX_SHIM_EXEC+x}" ] || cis_exec=$CODEX_SHIM_EXEC
 
 # --- PATH: prepend the city's toolchain, then remove the shim's own directory ---
-if [ -n "${CODEX_SHIM_PATH_PREPEND:-}" ]; then
-  PATH="$CODEX_SHIM_PATH_PREPEND:$PATH"
+if [ -n "${cis_prepend:-}" ]; then
+  PATH="$cis_prepend:$PATH"
 fi
-pruned=
-old_ifs=$IFS
-set -f
-IFS=:
-for entry in $PATH; do
-  phys=$(cd -- "${entry:-.}" 2>/dev/null && pwd -P) || phys=
-  if [ -n "$self_dir" ] && [ "$phys" = "$self_dir" ]; then
-    continue
+cis_rest=$PATH
+cis_pruned=
+cis_first=1
+while :; do
+  case $cis_rest in
+    *:*) cis_entry=${cis_rest%%:*}; cis_rest=${cis_rest#*:}; cis_more=1 ;;
+    *) cis_entry=$cis_rest; cis_more=0 ;;
+  esac
+  cis_phys=$(cd -- "${cis_entry:-.}" 2>/dev/null && pwd -P) || cis_phys=
+  if [ "$cis_phys" != "$cis_self_dir" ]; then
+    if [ "$cis_first" = 1 ]; then
+      cis_pruned=$cis_entry
+      cis_first=0
+    else
+      cis_pruned="$cis_pruned:$cis_entry"
+    fi
   fi
-  pruned="${pruned:+$pruned:}$entry"
+  [ "$cis_more" = 1 ] || break
 done
-IFS=$old_ifs
-set +f
-PATH=$pruned
+PATH=$cis_pruned
 export PATH
 
-# --- Infisical machine identity, fail-open -------------------------------------
-token_sh="${HOME:-}/.config/infisical-agent/token.sh"
-if [ -z "${INFISICAL_TOKEN:-}" ] && [ -n "${HOME:-}" ] && [ -r "$token_sh" ]; then
+# --- Infisical machine identity, fail-open, helper isolated in a subshell --------
+cis_token_sh="${HOME:-}/.config/infisical-agent/token.sh"
+if [ -z "${INFISICAL_TOKEN:-}" ] && [ -n "${HOME:-}" ] && [ -r "$cis_token_sh" ]; then
   # shellcheck disable=SC1090
-  . "$token_sh" 2>/dev/null \
-    || { unset INFISICAL_TOKEN; echo "codex-infisical-shim: WARN Infisical machine-identity login failed; INFISICAL_TOKEN unset" >&2; }
+  if cis_token=$(. "$cis_token_sh" >/dev/null 2>&1 && printf '%s' "${INFISICAL_TOKEN-}") \
+     && [ -n "$cis_token" ]; then
+    INFISICAL_TOKEN=$cis_token
+    export INFISICAL_TOKEN
+  else
+    unset INFISICAL_TOKEN
+    echo "codex-infisical-shim: WARN Infisical machine-identity login failed; INFISICAL_TOKEN unset" >&2
+  fi
+  unset cis_token
 fi
 
 # --- exec the real codex --------------------------------------------------------
-if [ -n "${CODEX_SHIM_EXEC:-}" ]; then
-  set -f
-  # shellcheck disable=SC2086
-  set -- $CODEX_SHIM_EXEC "$@"
-  set +f
+set -f
+# shellcheck disable=SC2206
+cis_words=(${cis_exec:-})
+set +f
+if [ "${#cis_words[@]}" -gt 0 ]; then
+  set -- "${cis_words[@]}" "$@"
 else
   set -- codex "$@"
 fi
-target=$(command -v -- "$1" 2>/dev/null)
-if [ -z "$target" ]; then
-  echo "codex-infisical-shim: ERROR no '$1' on PATH after removing the shim's directory ($self_dir); set CODEX_SHIM_EXEC or install codex" >&2
-  exit 127
+cis_target=$(command -v -- "$1" 2>/dev/null)
+[ -n "$cis_target" ] \
+  || cis_die "no '$1' on PATH after removing the shim's directory ($cis_self_dir); set CODEX_SHIM_EXEC or install codex"
+if [ "$cis_target" -ef "$cis_self_file" ]; then
+  cis_die "'$1' resolves to the shim itself ($cis_self_file); refusing to exec"
 fi
-if [ "$target" -ef "$self_file" ]; then
-  echo "codex-infisical-shim: ERROR '$1' resolves to the shim itself ($self_file); refusing to exec" >&2
-  exit 127
-fi
+unset cis_self cis_self_dir cis_self_file cis_sidecar cis_line cis_key cis_val cis_prepend cis_exec \
+  cis_rest cis_pruned cis_first cis_entry cis_more cis_phys cis_token_sh cis_words cis_target
+unset -f cis_die
 exec "$@"

--- a/gascity/tests/test_codex_infisical_shim.py
+++ b/gascity/tests/test_codex_infisical_shim.py
@@ -108,6 +108,23 @@ def fenced_blocks(section: str, lang: str) -> list[str]:
     return re.findall(rf"```{lang}\n(.*?)```", section, re.S)
 
 
+def md5_tool_dir(root: pathlib.Path) -> str:
+    """Directory holding an `md5 -q` command: the macOS tool, else a wrapper over
+    md5sum (the README names it as the Linux equivalent) so the recipe runs on
+    the repository's Ubuntu CI as well."""
+    found = shutil.which("md5")
+    if found:
+        return os.path.dirname(found)
+    if shutil.which("md5sum") is None:
+        raise unittest.SkipTest("neither md5 nor md5sum on PATH")
+    d = root / "md5-tool"
+    d.mkdir()
+    tool = d / "md5"
+    tool.write_text('#!/bin/sh\n[ "$1" = -q ] && shift\nmd5sum -- "$@" | cut -d" " -f1\n', encoding="utf-8")
+    tool.chmod(0o755)
+    return str(d)
+
+
 class CodexInfisicalShimTests(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
@@ -139,7 +156,7 @@ class CodexInfisicalShimTests(unittest.TestCase):
             "CODEX_SHIM_PATH_PREPEND",
             "CODEX_SHIM_EXEC",
             "INFISICAL_PROJECT_ID",
-            "| md5 -q",
+            '&& md5 -q "$canonical"',
             "= <that md5>",
         ):
             self.assertIn(needle, text)
@@ -157,18 +174,14 @@ class CodexInfisicalShimTests(unittest.TestCase):
             "CODEX_SHIM_EXEC",
             "resume_command",
             "INFISICAL_PROJECT_ID",
-            "| md5 -q",
+            '&& md5 -q "$canonical"',
             "= <that md5>",
             "fail-open",
         ):
             self.assertIn(needle, section)
 
     def test_readme_install_recipe_works_from_a_fresh_directory(self) -> None:
-        if shutil.which("md5") is None:
-            self.skipTest("md5 (macOS) not on PATH")
-        blocks = fenced_blocks(readme_section(), "sh")
-        self.assertEqual(len(blocks), 2, "README section: one install block, one verify block")
-        install, verify = blocks
+        install = fenced_blocks(readme_section(), "sh")[0]
         city = self.fx.root / "fresh-city"
         city.mkdir()
         install = install.replace("path/to/gascity/", f"{PACK}/")
@@ -184,13 +197,47 @@ class CodexInfisicalShimTests(unittest.TestCase):
             (installed.parent / "codex.env").read_text(encoding="utf-8"),
             "CODEX_SHIM_PATH_PREPEND=/abs/path/to/city/.gc/shims/toolchain\nCODEX_SHIM_EXEC=npx -y @openai/codex@0.153.3\n",
         )
-        # The verify block: the recorded md5 is a literal, so the check fails when
-        # the installed file is missing instead of matching two empty strings.
-        canonical_md5 = subprocess.run(["md5", "-q", str(SCRIPT)], capture_output=True, text=True, check=True).stdout.strip()
-        check = verify.splitlines()[-1].replace("<that md5>", canonical_md5)
-        self.assertTrue(check.startswith('test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" ='), check)
-        env = {"PATH": f"{SYSTEM_PATH}:{os.path.dirname(shutil.which('md5'))}", "CITY": str(city)}
+
+    def test_readme_verify_recipe_records_a_literal_md5_and_fails_closed(self) -> None:
+        import hashlib
+        blocks = fenced_blocks(readme_section(), "sh")
+        self.assertEqual(len(blocks), 2, "README section: one install block, one verify block")
+        record, check = blocks[1].splitlines()
+        tool_path = f"{SYSTEM_PATH}:{md5_tool_dir(self.fx.root)}"
+        repo = subprocess.run(["git", "-C", str(PACK), "rev-parse", "--show-toplevel"], capture_output=True, text=True)
+        if repo.returncode != 0:
+            self.skipTest("pack is not inside a git checkout")
+        repo_root = repo.stdout.strip()
+        rel = SCRIPT.relative_to(repo_root).as_posix()
+        self.assertIn(f"show <pin>:{rel} >", record)
+        committed = subprocess.run(["git", "-C", repo_root, "show", f"HEAD:{rel}"], capture_output=True)
+        if committed.returncode != 0:
+            self.skipTest("canonical file not committed yet")
+        expected = hashlib.md5(committed.stdout).hexdigest()
+        # Recording: the pipeline-free form prints the committed file's md5 and
+        # prints nothing (non-zero) for a pin that does not resolve.
+        rec = record.replace("path/to/gascity-packs", repo_root).replace("<pin>", "HEAD")
+        proc = subprocess.run(["/bin/sh", "-c", rec], env={"PATH": tool_path, "TMPDIR": str(self.fx.root)},
+                              capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), expected)
+        bad = record.replace("path/to/gascity-packs", repo_root).replace("<pin>", "no-such-pin-000")
+        proc = subprocess.run(["/bin/sh", "-c", bad], env={"PATH": tool_path, "TMPDIR": str(self.fx.root)},
+                              capture_output=True, text=True)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertEqual(proc.stdout, "", "a bad pin must record nothing, not the hash of empty input")
+        # Checking: the recorded md5 is a literal, so the check fails when the
+        # installed file is missing or the md5 tool is, instead of matching "".
+        city = self.fx.root / "city"
+        installed = city / ".gc" / "shims" / "codex-astra" / "codex"
+        installed.parent.mkdir(parents=True)
+        installed.write_bytes(committed.stdout)
+        self.assertTrue(check.startswith('test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" = <that md5>'), check)
+        check = check.replace("<that md5>", expected)
+        env = {"PATH": tool_path, "CITY": str(city)}
         self.assertEqual(subprocess.run(["/bin/sh", "-c", check], env=env).returncode, 0)
+        installed.write_bytes(committed.stdout + b"# drift\n")
+        self.assertNotEqual(subprocess.run(["/bin/sh", "-c", check], env=env).returncode, 0)
         env["CITY"] = str(self.fx.root / "no-such-city")
         self.assertNotEqual(subprocess.run(["/bin/sh", "-c", check], env=env, capture_output=True).returncode, 0)
         self.assertEqual(subprocess.run(["/bin/sh", "-c", check], env={"PATH": "/nonexistent", "CITY": str(city)},
@@ -259,6 +306,24 @@ class CodexInfisicalShimTests(unittest.TestCase):
         proc = self.fx.run("-p", "city", "keep")
         self.assert_exec_ok(proc, ["-p", "city", "keep"])
         self.assertEqual(self.fx.recorded("token"), "tok")
+
+    def test_helper_tracing_cannot_print_the_token(self) -> None:
+        self.fx.write_token_sh("set -x\nexport INFISICAL_TOKEN=traced-token-xyz\n")
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("token"), "traced-token-xyz")
+        self.assertEqual(proc.stdout, "")
+        self.assertEqual(proc.stderr, "")
+
+    def test_helper_exit_trap_cannot_print_or_alter_the_token(self) -> None:
+        self.fx.write_token_sh(
+            "trap 'echo trailing-stdout; echo trailing-stderr >&2' EXIT\nexport INFISICAL_TOKEN=exact-token\n"
+        )
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("token"), "exact-token")
+        self.assertEqual(proc.stdout, "")
+        self.assertEqual(proc.stderr, "")
 
     def test_a_set_token_is_kept_and_token_sh_is_not_sourced(self) -> None:
         self.fx.write_token_sh("export INFISICAL_TOKEN=minted\ntouch \"$SHIM_TEST_OUT/sourced\"\n")
@@ -330,6 +395,24 @@ class CodexInfisicalShimTests(unittest.TestCase):
     def test_no_codex_left_on_path_is_an_error_not_a_loop(self) -> None:
         proc = self.fx.run("-p", "city", path=f"{self.fx.shim_dir}:{SYSTEM_PATH}")
         self.assert_refused(proc, "ERROR no 'codex' on PATH after removing the shim's directory")
+
+    def test_pruning_every_entry_never_makes_path_the_current_directory(self) -> None:
+        cwd = self.fx.root / "cwd-with-codex"
+        self.fx.write_exec(cwd / "codex", FAKE_CODEX)
+        proc = self.fx.run("-p", "city", path=str(self.fx.shim_dir), cwd=cwd)
+        self.assert_refused(proc, "ERROR no 'codex' on PATH")
+        proc = self.fx.run("-p", "city", path=str(self.fx.shim_dir), cwd=cwd, env_extra={"CODEX_SHIM_EXEC": str(self.fx.fake)})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), "/dev/null")
+        self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), self.fx.fake.resolve())
+
+    def test_cdpath_does_not_disturb_self_location_or_pruning(self) -> None:
+        rel_shim = os.path.relpath(self.fx.shim, self.fx.root)
+        rel_dir = os.path.relpath(self.fx.shim_dir, self.fx.root)
+        proc = self.fx.run("-p", "city", argv0=rel_shim, path=f"{rel_dir}:{self.fx.bin}:{SYSTEM_PATH}",
+                           env_extra={"CDPATH": f".:{self.fx.root}"})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
 
     def test_a_symlink_to_the_shim_elsewhere_on_path_is_refused_not_execd(self) -> None:
         link_dir = self.fx.root / "elsewhere"
@@ -447,6 +530,14 @@ class CodexInfisicalShimTests(unittest.TestCase):
         self.assert_exec_ok(proc, ["--ok", "-p", "city"])
         self.assertEqual(self.fx.recorded("entry"), "keep-me")
         self.assertEqual(self.fx.recorded("line"), "keep-line")
+
+    def test_inherited_cis_variables_are_not_configuration(self) -> None:
+        proc = self.fx.run("-p", "city", env_extra={
+            "cis_exec": "/bin/echo INJECTED", "cis_prepend": "/nonexistent-inherited", "cis_first": "0", "cis_pruned": "/x",
+        })
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), self.fx.fake.resolve())
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
 
 
 if __name__ == "__main__":

--- a/gascity/tests/test_codex_infisical_shim.py
+++ b/gascity/tests/test_codex_infisical_shim.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import re
 import shutil
 import stat
 import subprocess
@@ -17,8 +18,9 @@ import tempfile
 import unittest
 
 
-SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "assets" / "scripts" / "codex-infisical-shim.sh"
-README = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+PACK = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = PACK / "assets" / "scripts" / "codex-infisical-shim.sh"
+README = PACK / "README.md"
 SYSTEM_PATH = "/usr/bin:/bin"
 
 FAKE_CODEX = """#!/bin/sh
@@ -30,6 +32,8 @@ printf '%s\\n' "$PATH" > "$out/path"
 printf '%s\\n' "${INFISICAL_TOKEN-<unset>}" > "$out/token"
 printf '%s\\n' "${SHIM_TEST_MARKER-<unset>}" > "$out/marker"
 printf '%s\\n' "${INFISICAL_UNIVERSAL_AUTH_CLIENT_ID-<unset>}" > "$out/client_id"
+printf '%s\\n' "${entry-<unset>}" > "$out/entry"
+printf '%s\\n' "${line-<unset>}" > "$out/line"
 exit 0
 """
 
@@ -67,7 +71,8 @@ class Fixture:
         return p
 
     def run(self, *args: str, path: str | None = None, env_extra: dict[str, str] | None = None,
-            argv0: str | None = None, timeout: float = 20.0) -> subprocess.CompletedProcess[str]:
+            argv0: str | None = None, cwd: pathlib.Path | None = None,
+            timeout: float = 20.0) -> subprocess.CompletedProcess[str]:
         env = {
             "HOME": str(self.home),
             "PATH": path if path is not None else f"{self.shim_dir}:{self.bin}:{SYSTEM_PATH}",
@@ -76,7 +81,7 @@ class Fixture:
         }
         return subprocess.run(
             [argv0 or str(self.shim), *args],
-            cwd=str(self.root),
+            cwd=str(cwd or self.root),
             env=env,
             capture_output=True,
             text=True,
@@ -94,6 +99,15 @@ class Fixture:
         return (self.out / "argv").exists()
 
 
+def readme_section() -> str:
+    text = README.read_text(encoding="utf-8")
+    return text.split("## Codex provider shim", 1)[1].split("\n## ", 1)[0]
+
+
+def fenced_blocks(section: str, lang: str) -> list[str]:
+    return re.findall(rf"```{lang}\n(.*?)```", section, re.S)
+
+
 class CodexInfisicalShimTests(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
@@ -107,61 +121,110 @@ class CodexInfisicalShimTests(unittest.TestCase):
         self.assertTrue(self.fx.ran_fake(), "the real codex did not run")
         self.assertEqual(self.fx.recorded_argv(), argv)
 
-    # --- canonical file ---------------------------------------------------------------
+    def assert_refused(self, proc: subprocess.CompletedProcess[str], needle: str) -> None:
+        self.assertEqual(proc.returncode, 127, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}")
+        self.assertIn(needle, proc.stderr)
+        self.assertFalse(self.fx.ran_fake(), "the fake codex ran although the shim should have refused")
+
+    # --- canonical file and recipe ----------------------------------------------------
 
     def test_canonical_file_is_executable_bash_and_documents_its_install(self) -> None:
         self.assertTrue(os.access(SCRIPT, os.X_OK), "canonical shim must carry the executable bit")
         text = SCRIPT.read_text(encoding="utf-8")
         self.assertTrue(text.startswith("#!/bin/bash\n"))
         for needle in (
-            'install -m 0755 path/to/gascity/assets/scripts/codex-infisical-shim.sh',
+            'mkdir -p "$CITY/.gc/shims/codex-astra"',
+            "install -m 0755 path/to/gascity/assets/scripts/codex-infisical-shim.sh",
             '"$CITY/.gc/shims/codex-astra/codex"',
             "CODEX_SHIM_PATH_PREPEND",
             "CODEX_SHIM_EXEC",
             "INFISICAL_PROJECT_ID",
-            "md5 -q",
+            "| md5 -q",
+            "= <that md5>",
         ):
             self.assertIn(needle, text)
         self.assertNotIn("set -x", text)
+        self.assertNotIn("eval ", text)
 
     def test_readme_carries_the_install_recipe(self) -> None:
-        text = README.read_text(encoding="utf-8")
-        self.assertIn("## Codex provider shim", text)
-        section = text.split("## Codex provider shim", 1)[1].split("\n## ", 1)[0]
+        section = readme_section()
         for needle in (
             "assets/scripts/codex-infisical-shim.sh",
+            'mkdir -p "$CITY/.gc/shims/codex-astra"',
             ".gc/shims/codex-astra/codex",
             "codex.env",
             "CODEX_SHIM_PATH_PREPEND",
             "CODEX_SHIM_EXEC",
             "resume_command",
             "INFISICAL_PROJECT_ID",
-            "md5 -q",
+            "| md5 -q",
+            "= <that md5>",
             "fail-open",
         ):
             self.assertIn(needle, section)
 
-    # --- fail-open token --------------------------------------------------------------
+    def test_readme_install_recipe_works_from_a_fresh_directory(self) -> None:
+        if shutil.which("md5") is None:
+            self.skipTest("md5 (macOS) not on PATH")
+        blocks = fenced_blocks(readme_section(), "sh")
+        self.assertEqual(len(blocks), 2, "README section: one install block, one verify block")
+        install, verify = blocks
+        city = self.fx.root / "fresh-city"
+        city.mkdir()
+        install = install.replace("path/to/gascity/", f"{PACK}/")
+        proc = subprocess.run(
+            ["/bin/sh", "-e", "-c", install], cwd=str(self.fx.root), env={"PATH": SYSTEM_PATH, "CITY": str(city)},
+            capture_output=True, text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        installed = city / ".gc" / "shims" / "codex-astra" / "codex"
+        self.assertEqual(installed.read_bytes(), SCRIPT.read_bytes())
+        self.assertTrue(os.access(installed, os.X_OK))
+        self.assertEqual(
+            (installed.parent / "codex.env").read_text(encoding="utf-8"),
+            "CODEX_SHIM_PATH_PREPEND=/abs/path/to/city/.gc/shims/toolchain\nCODEX_SHIM_EXEC=npx -y @openai/codex@0.153.3\n",
+        )
+        # The verify block: the recorded md5 is a literal, so the check fails when
+        # the installed file is missing instead of matching two empty strings.
+        canonical_md5 = subprocess.run(["md5", "-q", str(SCRIPT)], capture_output=True, text=True, check=True).stdout.strip()
+        check = verify.splitlines()[-1].replace("<that md5>", canonical_md5)
+        self.assertTrue(check.startswith('test "$(md5 -q "$CITY/.gc/shims/codex-astra/codex")" ='), check)
+        env = {"PATH": f"{SYSTEM_PATH}:{os.path.dirname(shutil.which('md5'))}", "CITY": str(city)}
+        self.assertEqual(subprocess.run(["/bin/sh", "-c", check], env=env).returncode, 0)
+        env["CITY"] = str(self.fx.root / "no-such-city")
+        self.assertNotEqual(subprocess.run(["/bin/sh", "-c", check], env=env, capture_output=True).returncode, 0)
+        self.assertEqual(subprocess.run(["/bin/sh", "-c", check], env={"PATH": "/nonexistent", "CITY": str(city)},
+                                        capture_output=True).returncode, 1, "a missing md5 tool must fail the check")
+
+    # --- fail-open token, helper isolated ---------------------------------------------
 
     def test_absent_token_sh_execs_codex_with_argv_intact_and_no_warning(self) -> None:
-        proc = self.fx.run("-p", "city", "--model", "gpt-6-astra", "a b", "", "-")
-        self.assert_exec_ok(proc, ["-p", "city", "--model", "gpt-6-astra", "a b", "", "-"])
+        proc = self.fx.run("-p", "city", "--model", "gpt-6-astra", "a b", "", "-", "*")
+        self.assert_exec_ok(proc, ["-p", "city", "--model", "gpt-6-astra", "a b", "", "-", "*"])
         self.assertEqual(proc.stderr, "")
         self.assertEqual(self.fx.recorded("token"), "<unset>")
 
-    def test_present_token_sh_is_sourced_and_its_exports_reach_codex(self) -> None:
+    def test_present_token_sh_is_sourced_and_only_its_token_crosses_over(self) -> None:
         self.fx.write_token_sh(
             "set -a\nINFISICAL_UNIVERSAL_AUTH_CLIENT_ID=cid\nset +a\n"
-            "export INFISICAL_TOKEN=tok-marker-123\nexport SHIM_TEST_MARKER=marker-reached\n"
+            "export INFISICAL_TOKEN=tok-marker-123\nexport SHIM_TEST_MARKER=must-not-cross\n"
+            "echo 'helper noise' ; echo \"$INFISICAL_TOKEN\"\n"
             "unset INFISICAL_UNIVERSAL_AUTH_CLIENT_ID\n"
         )
         proc = self.fx.run("resume", "sess-1")
         self.assert_exec_ok(proc, ["resume", "sess-1"])
         self.assertEqual(proc.stderr, "")
+        self.assertEqual(proc.stdout, "", "nothing the helper prints may reach the session output")
         self.assertEqual(self.fx.recorded("token"), "tok-marker-123")
-        self.assertEqual(self.fx.recorded("marker"), "marker-reached")
+        self.assertEqual(self.fx.recorded("marker"), "<unset>")
         self.assertEqual(self.fx.recorded("client_id"), "<unset>")
-        self.assertNotIn("tok-marker-123", proc.stdout + proc.stderr)
+
+    def test_helper_that_leaves_client_secret_exported_does_not_leak_it(self) -> None:
+        self.fx.write_token_sh("export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID=cid\nexport INFISICAL_TOKEN=tok\n")
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("token"), "tok")
+        self.assertEqual(self.fx.recorded("client_id"), "<unset>")
 
     def test_failing_token_sh_warns_once_unsets_the_token_and_still_execs(self) -> None:
         self.fx.write_token_sh(
@@ -170,23 +233,50 @@ class CodexInfisicalShimTests(unittest.TestCase):
         )
         proc = self.fx.run("-p", "city")
         self.assert_exec_ok(proc, ["-p", "city"])
-        self.assertEqual(proc.stderr.count("WARN"), 1)
-        self.assertIn("codex-infisical-shim: WARN Infisical machine-identity login failed; INFISICAL_TOKEN unset", proc.stderr)
-        self.assertNotIn("universal-auth login failed\n", proc.stderr.replace("machine-identity login failed", ""))
+        self.assertEqual(
+            proc.stderr,
+            "codex-infisical-shim: WARN Infisical machine-identity login failed; INFISICAL_TOKEN unset\n",
+        )
         self.assertEqual(self.fx.recorded("token"), "<unset>")
-        self.assertEqual(self.fx.recorded("marker"), "partial")
+        self.assertEqual(self.fx.recorded("marker"), "<unset>")
+
+    def test_helper_that_exits_cannot_end_the_shim(self) -> None:
+        self.fx.write_token_sh("export INFISICAL_TOKEN=tok\nexit 1\n")
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(proc.stderr.count("WARN"), 1)
+        self.assertEqual(self.fx.recorded("token"), "<unset>")
+
+    def test_helper_that_succeeds_without_a_token_warns(self) -> None:
+        self.fx.write_token_sh("true\n")
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(proc.stderr.count("WARN"), 1)
+        self.assertEqual(self.fx.recorded("token"), "<unset>")
+
+    def test_helper_that_rewrites_argv_cannot_change_what_codex_receives(self) -> None:
+        self.fx.write_token_sh("set -- dropped --by helper\nexport INFISICAL_TOKEN=tok\n")
+        proc = self.fx.run("-p", "city", "keep")
+        self.assert_exec_ok(proc, ["-p", "city", "keep"])
+        self.assertEqual(self.fx.recorded("token"), "tok")
 
     def test_a_set_token_is_kept_and_token_sh_is_not_sourced(self) -> None:
-        self.fx.write_token_sh("export INFISICAL_TOKEN=minted\nexport SHIM_TEST_MARKER=sourced\n")
+        self.fx.write_token_sh("export INFISICAL_TOKEN=minted\ntouch \"$SHIM_TEST_OUT/sourced\"\n")
         proc = self.fx.run("-p", "city", env_extra={"INFISICAL_TOKEN": "already-there"})
         self.assert_exec_ok(proc, ["-p", "city"])
         self.assertEqual(self.fx.recorded("token"), "already-there")
-        self.assertEqual(self.fx.recorded("marker"), "<unset>")
+        self.assertFalse((self.fx.out / "sourced").exists())
+
+    def test_an_empty_token_is_minted_like_an_unset_one(self) -> None:
+        self.fx.write_token_sh("export INFISICAL_TOKEN=minted\n")
+        proc = self.fx.run("-p", "city", env_extra={"INFISICAL_TOKEN": ""})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("token"), "minted")
 
     def test_unreadable_token_sh_is_treated_as_absent(self) -> None:
         if os.geteuid() == 0:
             self.skipTest("root reads everything")
-        p = self.fx.write_token_sh("export SHIM_TEST_MARKER=sourced\n")
+        p = self.fx.write_token_sh("export INFISICAL_TOKEN=minted\n")
         p.chmod(0)
         try:
             proc = self.fx.run("-p", "city")
@@ -194,7 +284,16 @@ class CodexInfisicalShimTests(unittest.TestCase):
             p.chmod(0o644)
         self.assert_exec_ok(proc, ["-p", "city"])
         self.assertEqual(proc.stderr, "")
-        self.assertEqual(self.fx.recorded("marker"), "<unset>")
+        self.assertEqual(self.fx.recorded("token"), "<unset>")
+
+    def test_unset_home_skips_the_helper(self) -> None:
+        proc = subprocess.run(
+            [str(self.fx.shim), "-p", "city"], cwd=str(self.fx.root),
+            env={"PATH": f"{self.fx.shim_dir}:{self.fx.bin}:{SYSTEM_PATH}", "SHIM_TEST_OUT": str(self.fx.out)},
+            capture_output=True, text=True, timeout=20,
+        )
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(proc.stderr, "")
 
     # --- never execs itself -----------------------------------------------------------
 
@@ -218,26 +317,55 @@ class CodexInfisicalShimTests(unittest.TestCase):
         self.assert_exec_ok(proc, ["-p", "city"])
         self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
 
+    def test_empty_path_entries_are_kept_unless_they_are_the_shim_directory(self) -> None:
+        proc = self.fx.run("-p", "city", path=f":{self.fx.shim_dir}:{self.fx.bin}::{SYSTEM_PATH}:")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), f":{self.fx.bin}::{SYSTEM_PATH}:")
+        # An empty entry means the current directory; from inside the shim's
+        # directory it resolves to the shim and is pruned like any other alias.
+        proc = self.fx.run("-p", "city", path=f":{self.fx.bin}:{SYSTEM_PATH}", cwd=self.fx.shim_dir)
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
+
     def test_no_codex_left_on_path_is_an_error_not_a_loop(self) -> None:
         proc = self.fx.run("-p", "city", path=f"{self.fx.shim_dir}:{SYSTEM_PATH}")
-        self.assertEqual(proc.returncode, 127)
-        self.assertIn("ERROR no 'codex' on PATH after removing the shim's directory", proc.stderr)
-        self.assertFalse(self.fx.ran_fake())
+        self.assert_refused(proc, "ERROR no 'codex' on PATH after removing the shim's directory")
 
     def test_a_symlink_to_the_shim_elsewhere_on_path_is_refused_not_execd(self) -> None:
         link_dir = self.fx.root / "elsewhere"
         link_dir.mkdir()
         (link_dir / "codex").symlink_to(self.fx.shim)
         proc = self.fx.run("-p", "city", path=f"{self.fx.shim_dir}:{link_dir}:{self.fx.bin}:{SYSTEM_PATH}")
-        self.assertEqual(proc.returncode, 127)
-        self.assertIn("resolves to the shim itself", proc.stderr)
-        self.assertFalse(self.fx.ran_fake())
+        self.assert_refused(proc, "resolves to the shim itself")
 
     def test_exec_override_naming_the_shim_itself_is_refused(self) -> None:
         proc = self.fx.run("-p", "city", env_extra={"CODEX_SHIM_EXEC": str(self.fx.shim)})
-        self.assertEqual(proc.returncode, 127)
-        self.assertIn("resolves to the shim itself", proc.stderr)
-        self.assertFalse(self.fx.ran_fake())
+        self.assert_refused(proc, "resolves to the shim itself")
+
+    def test_no_utility_on_path_still_refuses_self_exec_and_still_execs_an_absolute_target(self) -> None:
+        proc = self.fx.run("-p", "city", path="/nonexistent", env_extra={"CODEX_SHIM_EXEC": str(self.fx.shim)})
+        self.assert_refused(proc, "resolves to the shim itself")
+        proc = self.fx.run("-p", "city", path="/nonexistent", env_extra={"CODEX_SHIM_EXEC": str(self.fx.fake)})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), "/nonexistent")
+
+    def test_shim_that_cannot_locate_itself_refuses(self) -> None:
+        # bash -c 'source' style invocation: $0 is a bare name that is not on PATH.
+        proc = subprocess.run(
+            ["/bin/bash", str(self.fx.shim), "-p", "city"], cwd=str(self.fx.root),
+            env={"HOME": str(self.fx.home), "PATH": "/nonexistent", "SHIM_TEST_OUT": str(self.fx.out),
+                 "CODEX_SHIM_EXEC": str(self.fx.fake)},
+            capture_output=True, text=True, timeout=20,
+        )
+        self.assert_exec_ok(proc, ["-p", "city"])  # a path with a slash locates itself without PATH
+        proc = subprocess.run(
+            ["/bin/bash", "-c", '. "$1"', "codex-not-on-path", str(self.fx.shim)], cwd=str(self.fx.root),
+            env={"HOME": str(self.fx.home), "PATH": "/nonexistent", "SHIM_TEST_OUT": str(self.fx.out / "none"),
+                 "CODEX_SHIM_EXEC": str(self.fx.fake)},
+            capture_output=True, text=True, timeout=20,
+        )
+        self.assertEqual(proc.returncode, 127, proc.stderr)
+        self.assertIn("cannot locate the shim itself", proc.stderr)
 
     # --- settings: environment over <shim>.env ----------------------------------------
 
@@ -267,16 +395,35 @@ class CodexInfisicalShimTests(unittest.TestCase):
         self.assertTrue(self.fx.recorded("path").startswith(f"{other.parent}:"))
         self.assertNotIn("/nonexistent-sidecar", self.fx.recorded("path"))
 
+    def test_an_empty_environment_value_still_wins_over_the_sidecar(self) -> None:
+        self.fx.write_sidecar("CODEX_SHIM_EXEC=never-runs\nCODEX_SHIM_PATH_PREPEND=/nonexistent-sidecar\n")
+        proc = self.fx.run("-p", "city", env_extra={"CODEX_SHIM_EXEC": "", "CODEX_SHIM_PATH_PREPEND": ""})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), self.fx.fake.resolve())
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
+
+    def test_a_blank_exec_override_never_runs_a_caller_argument(self) -> None:
+        proc = self.fx.run("/bin/echo", "WRONG_EXECUTABLE", env_extra={"CODEX_SHIM_EXEC": "   "})
+        self.assert_exec_ok(proc, ["/bin/echo", "WRONG_EXECUTABLE"])
+        self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), self.fx.fake.resolve())
+        self.fx.write_sidecar("CODEX_SHIM_EXEC=\n")
+        proc = self.fx.run("/bin/echo", "WRONG_EXECUTABLE")
+        self.assert_exec_ok(proc, ["/bin/echo", "WRONG_EXECUTABLE"])
+
     def test_sidecar_is_not_evaluated_and_quotes_are_stripped(self) -> None:
         canary = self.fx.root / "canary"
         self.fx.write_sidecar(f'CODEX_SHIM_EXEC="$(touch {canary})"\n')
         proc = self.fx.run("-p", "city")
-        self.assertEqual(proc.returncode, 127)
+        self.assert_refused(proc, "ERROR no '$(touch' on PATH")
         self.assertFalse(canary.exists(), "sidecar value was evaluated by a shell")
-        self.assertIn("ERROR no '$(touch' on PATH", proc.stderr)
         self.fx.write_sidecar("CODEX_SHIM_EXEC='codex --quoted'\n")
         proc = self.fx.run("-p", "city")
         self.assert_exec_ok(proc, ["--quoted", "-p", "city"])
+
+    def test_exec_override_words_are_not_globbed(self) -> None:
+        (self.fx.root / "glob-a").touch()
+        proc = self.fx.run("-p", "city", env_extra={"CODEX_SHIM_EXEC": "codex --pattern glob-*"})
+        self.assert_exec_ok(proc, ["--pattern", "glob-*", "-p", "city"])
 
     def test_unknown_sidecar_keys_warn_and_are_ignored(self) -> None:
         self.fx.write_sidecar("BOGUS=1\nno-equals-line\nCODEX_SHIM_EXEC=codex --ok\n")
@@ -290,6 +437,16 @@ class CodexInfisicalShimTests(unittest.TestCase):
         proc = self.fx.run("-p", "city")
         self.assert_exec_ok(proc, ["-p", "city"])
         self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
+
+    # --- environment preservation -----------------------------------------------------
+
+    def test_inherited_exports_named_like_scratch_variables_reach_codex_unchanged(self) -> None:
+        self.fx.write_sidecar("CODEX_SHIM_EXEC=codex --ok\n")
+        self.fx.write_token_sh("export INFISICAL_TOKEN=tok\n")
+        proc = self.fx.run("-p", "city", env_extra={"entry": "keep-me", "line": "keep-line", "PATH_PREPEND": "keep-p"})
+        self.assert_exec_ok(proc, ["--ok", "-p", "city"])
+        self.assertEqual(self.fx.recorded("entry"), "keep-me")
+        self.assertEqual(self.fx.recorded("line"), "keep-line")
 
 
 if __name__ == "__main__":

--- a/gascity/tests/test_codex_infisical_shim.py
+++ b/gascity/tests/test_codex_infisical_shim.py
@@ -175,7 +175,7 @@ class CodexInfisicalShimTests(unittest.TestCase):
         # by the one restore line just before the exec.
         body = text.split("\n\n", 1)[1]  # past the header comment
         self.assertEqual(text.count("set -x"), 1)
-        self.assertIn('{ set -x; exec -a "$3" "$2" "${@:4}" 2>&3 3>&-; } 3>&2 2>/dev/null', text)
+        self.assertIn('{ set -x; exec -a "$3" "$2" "${@:4}" >&4 2>&3 3>&- 4>&-; } 3>&2 4>&1 >/dev/null 2>&1', text)
         self.assertLess(body.index("set +x"), body.index("INFISICAL_TOKEN"))
 
     def test_readme_carries_the_install_recipe(self) -> None:
@@ -602,6 +602,30 @@ class CodexInfisicalShimTests(unittest.TestCase):
         self.assertEqual([l for l in proc.stderr.splitlines() if l not in fake_own], [], proc.stderr)
         self.assertIn("xtrace", self.fx.recorded("shellopts"))
         self.assertEqual(self.fx.recorded("token"), "ps4-dummy-secret")
+
+    def test_trace_descriptor_on_stdout_prints_no_token_either(self) -> None:
+        # BASH_XTRACEFD (bash >= 4.1) moves traces off stderr; bash 3.2 ignores
+        # it. The shebang interpreter is bash 5 on Linux; on macOS a Homebrew
+        # bash, when installed, runs the row for real as well.
+        interpreters: list[list[str]] = [[]]
+        for candidate in ("/opt/homebrew/bin/bash", "/usr/local/bin/bash"):
+            if os.access(candidate, os.X_OK):
+                interpreters.append([candidate])
+        for fd in ("1", "2"):
+            for interp in interpreters:
+                self.fx.reset_out()
+                env = {
+                    "HOME": str(self.fx.home), "PATH": f"{self.fx.shim_dir}:{self.fx.bin}:{SYSTEM_PATH}",
+                    "SHIM_TEST_OUT": str(self.fx.out), "SHELLOPTS": "xtrace", "BASH_XTRACEFD": fd,
+                    "PS4": "${INFISICAL_TOKEN} ", "INFISICAL_TOKEN": "xtracefd-dummy-secret",
+                }
+                proc = subprocess.run([*interp, str(self.fx.shim), "-p", "city"], cwd=str(self.fx.root), env=env,
+                                      capture_output=True, text=True, timeout=20)
+                self.assert_exec_ok(proc, ["-p", "city"])
+                self.assertEqual(self.fx.recorded("token"), "xtracefd-dummy-secret")
+                fake_own = [l for l in (proc.stdout + proc.stderr).splitlines() if l.endswith("set +x") or "printf" in l]
+                others = [l for l in (proc.stdout + proc.stderr).splitlines() if l not in fake_own]
+                self.assertEqual(others, [], f"interp={interp} fd={fd}\nstdout={proc.stdout!r}\nstderr={proc.stderr!r}")
 
     def test_inherited_errexit_keeps_the_diagnostics_and_reaches_codex(self) -> None:
         proc = self.fx.run("-p", "city", path=f"{self.fx.shim_dir}:{SYSTEM_PATH}", env_extra={"SHELLOPTS": "errexit"})

--- a/gascity/tests/test_codex_infisical_shim.py
+++ b/gascity/tests/test_codex_infisical_shim.py
@@ -35,6 +35,8 @@ printf '%s\\n' "${INFISICAL_TOKEN-<unset>}" > "$out/token"
 printf '%s\\n' "${SHIM_TEST_MARKER-<unset>}" > "$out/marker"
 printf '%s\\n' "${INFISICAL_UNIVERSAL_AUTH_CLIENT_ID-<unset>}" > "$out/client_id"
 printf '%s\\n' "${entry-<unset>}" > "$out/entry"
+printf '%s\\n' "${cis_argv0-<unset>}" > "$out/cis_argv0"
+printf '%s\\n' "${cis_token-<unset>}" > "$out/cis_token"
 printf '%s\\n' "${line-<unset>}" > "$out/line"
 exit 0
 """
@@ -171,7 +173,7 @@ class CodexInfisicalShimTests(unittest.TestCase):
         # by the one restore line just before the exec.
         body = text.split("\n\n", 1)[1]  # past the header comment
         self.assertEqual(text.count("set -x"), 1)
-        self.assertIn('[ "$cis_restore_xtrace" = 1 ] && set -x', text)
+        self.assertIn('{ set -x; exec -a "$3" "$2" "${@:4}" 2>&3 3>&-; } 3>&2 2>/dev/null', text)
         self.assertLess(body.index("set +x"), body.index("INFISICAL_TOKEN"))
 
     def test_readme_carries_the_install_recipe(self) -> None:
@@ -580,12 +582,41 @@ class CodexInfisicalShimTests(unittest.TestCase):
         self.assertNotIn("review-dummy-secret", proc.stdout + proc.stderr)
         self.assertEqual(self.fx.recorded("token"), "review-dummy-secret")
         self.assertIn("xtrace", self.fx.recorded("shellopts"))
-        self.assertIn("+ exec -a codex", proc.stderr, "tracing is back on for the exec")
         self.fx.write_token_sh("export INFISICAL_TOKEN=minted-dummy-secret\n")
         proc = self.fx.run("-p", "city", env_extra={"SHELLOPTS": "xtrace"})
         self.assert_exec_ok(proc, ["-p", "city"])
         self.assertNotIn("minted-dummy-secret", proc.stdout + proc.stderr)
         self.assertEqual(self.fx.recorded("token"), "minted-dummy-secret")
+        # A PS4 that expands the token: the shim's own trace lines never print.
+        # The fake, a shell script that inherits xtrace, PS4 and the token by
+        # design, traces exactly its first two lines before its own `set +x`;
+        # every other stderr line would be the shim's.
+        proc = self.fx.run("-p", "city", env_extra={
+            "SHELLOPTS": "xtrace", "PS4": "${INFISICAL_TOKEN} ", "INFISICAL_TOKEN": "ps4-dummy-secret"})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(proc.stdout, "")
+        fake_own = [l for l in proc.stderr.splitlines() if l.endswith("set +x") or "printf" in l]
+        self.assertEqual(len(fake_own), 2, proc.stderr)
+        self.assertEqual([l for l in proc.stderr.splitlines() if l not in fake_own], [], proc.stderr)
+        self.assertIn("xtrace", self.fx.recorded("shellopts"))
+        self.assertEqual(self.fx.recorded("token"), "ps4-dummy-secret")
+
+    def test_inherited_errexit_keeps_the_diagnostics_and_reaches_codex(self) -> None:
+        proc = self.fx.run("-p", "city", path=f"{self.fx.shim_dir}:{SYSTEM_PATH}", env_extra={"SHELLOPTS": "errexit"})
+        self.assert_refused(proc, "ERROR no 'codex' on PATH after removing the shim's directory")
+        proc = subprocess.run(
+            ["/bin/bash", "-c", '. "$1"', "codex-not-on-path", str(self.fx.shim)], cwd=str(self.fx.root),
+            env={"HOME": str(self.fx.home), "PATH": "/nonexistent", "SHIM_TEST_OUT": str(self.fx.out),
+                 "SHELLOPTS": "errexit", "CODEX_SHIM_EXEC": str(self.fx.fake)},
+            capture_output=True, text=True, timeout=20,
+        )
+        self.assertEqual(proc.returncode, 127, proc.stderr)
+        self.assertIn("cannot locate the shim itself", proc.stderr)
+        self.fx.write_token_sh("export INFISICAL_TOKEN=tok\n")
+        proc = self.fx.run("-p", "city", env_extra={"SHELLOPTS": "errexit"})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("token"), "tok")
+        self.assertIn("errexit", self.fx.recorded("shellopts"))
 
     def test_inherited_noglob_reaches_codex_and_the_override_still_splits(self) -> None:
         proc = self.fx.run("-p", "city", env_extra={"SHELLOPTS": "noglob", "CODEX_SHIM_EXEC": "codex --a --b"})
@@ -600,6 +631,25 @@ class CodexInfisicalShimTests(unittest.TestCase):
         self.assert_exec_ok(proc, ["-p", "city"])
         self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), self.fx.fake.resolve())
         self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
+
+    def test_no_cis_scratch_name_reaches_codex_even_under_allexport(self) -> None:
+        # Every name the shim assigns is unset before the exec whether or not
+        # the assignment ran (cis_token only runs with a helper); a cis_ name the
+        # shim never touches passes through like any other inherited export.
+        for extra in ({}, {"SHELLOPTS": "allexport"}):
+            self.fx.reset_out()
+            proc = self.fx.run("-p", "city", env_extra={"cis_argv0": "preserve-me", "cis_token": "keep", **extra})
+            self.assert_exec_ok(proc, ["-p", "city"])
+            self.assertEqual(self.fx.recorded("cis_argv0"), "preserve-me")
+            self.assertEqual(self.fx.recorded("cis_token"), "<unset>")
+            self.assertEqual(self.fx.recorded("entry"), "<unset>")
+        text = SCRIPT.read_text(encoding="utf-8")
+        body = text.split("\n\n", 1)[1]
+        assigned = set(re.findall(r"^\s*(cis_[a-z_0-9]+)=", body, re.M))
+        unset_line = re.search(r"^unset (cis_[^\n]*\\\n[^\n]*)$", body, re.M)
+        self.assertIsNotNone(unset_line, "the unconditional unset list")
+        listed = set(re.findall(r"cis_[a-z_0-9]+", unset_line.group(1)))
+        self.assertEqual(assigned - listed, set(), "every assigned cis_ name is in the unset list")
 
 
 if __name__ == "__main__":

--- a/gascity/tests/test_codex_infisical_shim.py
+++ b/gascity/tests/test_codex_infisical_shim.py
@@ -24,6 +24,8 @@ README = PACK / "README.md"
 SYSTEM_PATH = "/usr/bin:/bin"
 
 FAKE_CODEX = """#!/bin/sh
+printf '%s\\n' "${SHELLOPTS-<unset>}" > "$SHIM_TEST_OUT/shellopts"
+set +x
 out="$SHIM_TEST_OUT"
 printf '%s\\n' "$0" > "$out/argv0"
 : > "$out/argv"
@@ -98,6 +100,10 @@ class Fixture:
     def ran_fake(self) -> bool:
         return (self.out / "argv").exists()
 
+    def reset_out(self) -> None:
+        for f in self.out.iterdir():
+            f.unlink()
+
 
 def readme_section() -> str:
     text = README.read_text(encoding="utf-8")
@@ -160,8 +166,13 @@ class CodexInfisicalShimTests(unittest.TestCase):
             "= <that md5>",
         ):
             self.assertIn(needle, text)
-        self.assertNotIn("set -x", text)
         self.assertNotIn("eval ", text)
+        # Tracing is switched off first thing and only ever switched back on
+        # by the one restore line just before the exec.
+        body = text.split("\n\n", 1)[1]  # past the header comment
+        self.assertEqual(text.count("set -x"), 1)
+        self.assertIn('[ "$cis_restore_xtrace" = 1 ] && set -x', text)
+        self.assertLess(body.index("set +x"), body.index("INFISICAL_TOKEN"))
 
     def test_readme_carries_the_install_recipe(self) -> None:
         section = readme_section()
@@ -421,6 +432,38 @@ class CodexInfisicalShimTests(unittest.TestCase):
         proc = self.fx.run("-p", "city", path=f"{self.fx.shim_dir}:{link_dir}:{self.fx.bin}:{SYSTEM_PATH}")
         self.assert_refused(proc, "resolves to the shim itself")
 
+    def test_exported_function_named_codex_neither_runs_nor_bypasses_the_guard(self) -> None:
+        # bash imports `BASH_FUNC_codex%%` from the environment as a function
+        # named codex; `command -v` would report the function, `exec` would not
+        # run it. The executable file is what must be checked and run.
+        fn = {"BASH_FUNC_codex%%": '() { echo FUNCTION-RAN; exit 99; }'}
+        proc = self.fx.run("-p", "city", env_extra=fn)
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertNotIn("FUNCTION-RAN", proc.stdout)
+        self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), self.fx.fake.resolve())
+        # Two spellings of the shim on PATH (A holds it, B/codex links to it)
+        # restored by the prepend on every hop: a refusal, never a loop.
+        self.fx.reset_out()
+        b = self.fx.root / "B"
+        b.mkdir()
+        (b / "codex").symlink_to(self.fx.shim)
+        proc = self.fx.run("-p", "city", path=f"{self.fx.bin}:{SYSTEM_PATH}",
+                           env_extra={**fn, "CODEX_SHIM_PATH_PREPEND": f"{self.fx.shim_dir}:{b}"})
+        self.assert_refused(proc, "resolves to the shim itself")
+
+    def test_the_checked_executable_file_is_what_runs(self) -> None:
+        # A shell fake sees its script path as $0, so argv[0] itself is not
+        # observable here; the file that ran is.
+        proc = self.fx.run("-p", "city", env_extra={"CODEX_SHIM_EXEC": "codex --pinned"})
+        self.assert_exec_ok(proc, ["--pinned", "-p", "city"])
+        self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), self.fx.fake.resolve())
+
+    def test_doubled_slash_spelling_of_the_shim_directory_is_pruned(self) -> None:
+        doubled = "/" + str(self.fx.shim_dir)
+        proc = self.fx.run("-p", "city", path=f"{doubled}:{self.fx.bin}:{SYSTEM_PATH}")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
+
     def test_exec_override_naming_the_shim_itself_is_refused(self) -> None:
         proc = self.fx.run("-p", "city", env_extra={"CODEX_SHIM_EXEC": str(self.fx.shim)})
         self.assert_refused(proc, "resolves to the shim itself")
@@ -530,6 +573,25 @@ class CodexInfisicalShimTests(unittest.TestCase):
         self.assert_exec_ok(proc, ["--ok", "-p", "city"])
         self.assertEqual(self.fx.recorded("entry"), "keep-me")
         self.assertEqual(self.fx.recorded("line"), "keep-line")
+
+    def test_inherited_xtrace_never_prints_the_token_and_reaches_codex(self) -> None:
+        proc = self.fx.run("-p", "city", env_extra={"SHELLOPTS": "xtrace", "INFISICAL_TOKEN": "review-dummy-secret"})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertNotIn("review-dummy-secret", proc.stdout + proc.stderr)
+        self.assertEqual(self.fx.recorded("token"), "review-dummy-secret")
+        self.assertIn("xtrace", self.fx.recorded("shellopts"))
+        self.assertIn("+ exec -a codex", proc.stderr, "tracing is back on for the exec")
+        self.fx.write_token_sh("export INFISICAL_TOKEN=minted-dummy-secret\n")
+        proc = self.fx.run("-p", "city", env_extra={"SHELLOPTS": "xtrace"})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertNotIn("minted-dummy-secret", proc.stdout + proc.stderr)
+        self.assertEqual(self.fx.recorded("token"), "minted-dummy-secret")
+
+    def test_inherited_noglob_reaches_codex_and_the_override_still_splits(self) -> None:
+        proc = self.fx.run("-p", "city", env_extra={"SHELLOPTS": "noglob", "CODEX_SHIM_EXEC": "codex --a --b"})
+        self.assert_exec_ok(proc, ["--a", "--b", "-p", "city"])
+        self.assertIn("noglob", self.fx.recorded("shellopts"))
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
 
     def test_inherited_cis_variables_are_not_configuration(self) -> None:
         proc = self.fx.run("-p", "city", env_extra={

--- a/gascity/tests/test_codex_infisical_shim.py
+++ b/gascity/tests/test_codex_infisical_shim.py
@@ -1,0 +1,296 @@
+"""Contract tests for gascity/assets/scripts/codex-infisical-shim.sh.
+
+Each test installs the shim the way a city does (a copy named `codex` in its
+own directory, optionally with a `codex.env` beside it), puts a fake `codex`
+further down PATH that records its argv and environment, and runs the shim
+with a throwaway HOME. One row per contract line in the script header.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "assets" / "scripts" / "codex-infisical-shim.sh"
+README = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+SYSTEM_PATH = "/usr/bin:/bin"
+
+FAKE_CODEX = """#!/bin/sh
+out="$SHIM_TEST_OUT"
+printf '%s\\n' "$0" > "$out/argv0"
+: > "$out/argv"
+for a in "$@"; do printf '%s\\n' "$a" >> "$out/argv"; done
+printf '%s\\n' "$PATH" > "$out/path"
+printf '%s\\n' "${INFISICAL_TOKEN-<unset>}" > "$out/token"
+printf '%s\\n' "${SHIM_TEST_MARKER-<unset>}" > "$out/marker"
+printf '%s\\n' "${INFISICAL_UNIVERSAL_AUTH_CLIENT_ID-<unset>}" > "$out/client_id"
+exit 0
+"""
+
+
+class Fixture:
+    def __init__(self, root: pathlib.Path) -> None:
+        self.root = root
+        self.home = root / "home"
+        self.shim_dir = root / "shims" / "codex-astra"
+        self.bin = root / "bin"
+        self.out = root / "out"
+        for d in (self.home, self.shim_dir, self.bin, self.out):
+            d.mkdir(parents=True)
+        self.shim = self.shim_dir / "codex"
+        shutil.copyfile(SCRIPT, self.shim)
+        self.shim.chmod(0o755)
+        self.fake = self.write_exec(self.bin / "codex", FAKE_CODEX)
+
+    def write_exec(self, path: pathlib.Path, body: str) -> pathlib.Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        return path
+
+    def write_token_sh(self, body: str) -> pathlib.Path:
+        d = self.home / ".config" / "infisical-agent"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "token.sh"
+        p.write_text(body, encoding="utf-8")
+        return p
+
+    def write_sidecar(self, text: str) -> pathlib.Path:
+        p = self.shim_dir / "codex.env"
+        p.write_text(text, encoding="utf-8")
+        return p
+
+    def run(self, *args: str, path: str | None = None, env_extra: dict[str, str] | None = None,
+            argv0: str | None = None, timeout: float = 20.0) -> subprocess.CompletedProcess[str]:
+        env = {
+            "HOME": str(self.home),
+            "PATH": path if path is not None else f"{self.shim_dir}:{self.bin}:{SYSTEM_PATH}",
+            "SHIM_TEST_OUT": str(self.out),
+            **(env_extra or {}),
+        }
+        return subprocess.run(
+            [argv0 or str(self.shim), *args],
+            cwd=str(self.root),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    def recorded(self, name: str) -> str:
+        return (self.out / name).read_text(encoding="utf-8").rstrip("\n")
+
+    def recorded_argv(self) -> list[str]:
+        text = (self.out / "argv").read_text(encoding="utf-8")
+        return text.split("\n")[:-1] if text else []
+
+    def ran_fake(self) -> bool:
+        return (self.out / "argv").exists()
+
+
+class CodexInfisicalShimTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.fx = Fixture(pathlib.Path(self._tmp.name).resolve())
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def assert_exec_ok(self, proc: subprocess.CompletedProcess[str], argv: list[str]) -> None:
+        self.assertEqual(proc.returncode, 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}")
+        self.assertTrue(self.fx.ran_fake(), "the real codex did not run")
+        self.assertEqual(self.fx.recorded_argv(), argv)
+
+    # --- canonical file ---------------------------------------------------------------
+
+    def test_canonical_file_is_executable_bash_and_documents_its_install(self) -> None:
+        self.assertTrue(os.access(SCRIPT, os.X_OK), "canonical shim must carry the executable bit")
+        text = SCRIPT.read_text(encoding="utf-8")
+        self.assertTrue(text.startswith("#!/bin/bash\n"))
+        for needle in (
+            'install -m 0755 path/to/gascity/assets/scripts/codex-infisical-shim.sh',
+            '"$CITY/.gc/shims/codex-astra/codex"',
+            "CODEX_SHIM_PATH_PREPEND",
+            "CODEX_SHIM_EXEC",
+            "INFISICAL_PROJECT_ID",
+            "md5 -q",
+        ):
+            self.assertIn(needle, text)
+        self.assertNotIn("set -x", text)
+
+    def test_readme_carries_the_install_recipe(self) -> None:
+        text = README.read_text(encoding="utf-8")
+        self.assertIn("## Codex provider shim", text)
+        section = text.split("## Codex provider shim", 1)[1].split("\n## ", 1)[0]
+        for needle in (
+            "assets/scripts/codex-infisical-shim.sh",
+            ".gc/shims/codex-astra/codex",
+            "codex.env",
+            "CODEX_SHIM_PATH_PREPEND",
+            "CODEX_SHIM_EXEC",
+            "resume_command",
+            "INFISICAL_PROJECT_ID",
+            "md5 -q",
+            "fail-open",
+        ):
+            self.assertIn(needle, section)
+
+    # --- fail-open token --------------------------------------------------------------
+
+    def test_absent_token_sh_execs_codex_with_argv_intact_and_no_warning(self) -> None:
+        proc = self.fx.run("-p", "city", "--model", "gpt-6-astra", "a b", "", "-")
+        self.assert_exec_ok(proc, ["-p", "city", "--model", "gpt-6-astra", "a b", "", "-"])
+        self.assertEqual(proc.stderr, "")
+        self.assertEqual(self.fx.recorded("token"), "<unset>")
+
+    def test_present_token_sh_is_sourced_and_its_exports_reach_codex(self) -> None:
+        self.fx.write_token_sh(
+            "set -a\nINFISICAL_UNIVERSAL_AUTH_CLIENT_ID=cid\nset +a\n"
+            "export INFISICAL_TOKEN=tok-marker-123\nexport SHIM_TEST_MARKER=marker-reached\n"
+            "unset INFISICAL_UNIVERSAL_AUTH_CLIENT_ID\n"
+        )
+        proc = self.fx.run("resume", "sess-1")
+        self.assert_exec_ok(proc, ["resume", "sess-1"])
+        self.assertEqual(proc.stderr, "")
+        self.assertEqual(self.fx.recorded("token"), "tok-marker-123")
+        self.assertEqual(self.fx.recorded("marker"), "marker-reached")
+        self.assertEqual(self.fx.recorded("client_id"), "<unset>")
+        self.assertNotIn("tok-marker-123", proc.stdout + proc.stderr)
+
+    def test_failing_token_sh_warns_once_unsets_the_token_and_still_execs(self) -> None:
+        self.fx.write_token_sh(
+            "export SHIM_TEST_MARKER=partial\nINFISICAL_TOKEN=short\nexport INFISICAL_TOKEN\n"
+            "echo 'infisical-agent: universal-auth login failed' >&2\nreturn 1 2>/dev/null || exit 1\n"
+        )
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(proc.stderr.count("WARN"), 1)
+        self.assertIn("codex-infisical-shim: WARN Infisical machine-identity login failed; INFISICAL_TOKEN unset", proc.stderr)
+        self.assertNotIn("universal-auth login failed\n", proc.stderr.replace("machine-identity login failed", ""))
+        self.assertEqual(self.fx.recorded("token"), "<unset>")
+        self.assertEqual(self.fx.recorded("marker"), "partial")
+
+    def test_a_set_token_is_kept_and_token_sh_is_not_sourced(self) -> None:
+        self.fx.write_token_sh("export INFISICAL_TOKEN=minted\nexport SHIM_TEST_MARKER=sourced\n")
+        proc = self.fx.run("-p", "city", env_extra={"INFISICAL_TOKEN": "already-there"})
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("token"), "already-there")
+        self.assertEqual(self.fx.recorded("marker"), "<unset>")
+
+    def test_unreadable_token_sh_is_treated_as_absent(self) -> None:
+        if os.geteuid() == 0:
+            self.skipTest("root reads everything")
+        p = self.fx.write_token_sh("export SHIM_TEST_MARKER=sourced\n")
+        p.chmod(0)
+        try:
+            proc = self.fx.run("-p", "city")
+        finally:
+            p.chmod(0o644)
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(proc.stderr, "")
+        self.assertEqual(self.fx.recorded("marker"), "<unset>")
+
+    # --- never execs itself -----------------------------------------------------------
+
+    def test_shim_directory_is_removed_from_path_and_the_next_codex_runs(self) -> None:
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
+        self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), self.fx.fake.resolve())
+
+    def test_invoked_by_bare_name_through_path_lookup_still_finds_the_real_codex(self) -> None:
+        proc = self.fx.run("-p", "city", argv0="codex")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
+
+    def test_symlinked_and_relative_aliases_of_the_shim_directory_are_pruned_too(self) -> None:
+        alias = self.fx.root / "alias-dir"
+        alias.symlink_to(self.fx.shim_dir, target_is_directory=True)
+        rel = os.path.relpath(self.fx.shim_dir, self.fx.root)
+        path = f"{self.fx.shim_dir}:{alias}:{rel}:{self.fx.bin}:{SYSTEM_PATH}"
+        proc = self.fx.run("-p", "city", path=path)
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
+
+    def test_no_codex_left_on_path_is_an_error_not_a_loop(self) -> None:
+        proc = self.fx.run("-p", "city", path=f"{self.fx.shim_dir}:{SYSTEM_PATH}")
+        self.assertEqual(proc.returncode, 127)
+        self.assertIn("ERROR no 'codex' on PATH after removing the shim's directory", proc.stderr)
+        self.assertFalse(self.fx.ran_fake())
+
+    def test_a_symlink_to_the_shim_elsewhere_on_path_is_refused_not_execd(self) -> None:
+        link_dir = self.fx.root / "elsewhere"
+        link_dir.mkdir()
+        (link_dir / "codex").symlink_to(self.fx.shim)
+        proc = self.fx.run("-p", "city", path=f"{self.fx.shim_dir}:{link_dir}:{self.fx.bin}:{SYSTEM_PATH}")
+        self.assertEqual(proc.returncode, 127)
+        self.assertIn("resolves to the shim itself", proc.stderr)
+        self.assertFalse(self.fx.ran_fake())
+
+    def test_exec_override_naming_the_shim_itself_is_refused(self) -> None:
+        proc = self.fx.run("-p", "city", env_extra={"CODEX_SHIM_EXEC": str(self.fx.shim)})
+        self.assertEqual(proc.returncode, 127)
+        self.assertIn("resolves to the shim itself", proc.stderr)
+        self.assertFalse(self.fx.ran_fake())
+
+    # --- settings: environment over <shim>.env ----------------------------------------
+
+    def test_sidecar_sets_the_exec_command_and_the_path_prepend(self) -> None:
+        tc = self.fx.root / "toolchain"
+        pinned = self.fx.write_exec(tc / "pinned-codex", FAKE_CODEX)
+        self.fx.write_sidecar(
+            "# per-city settings\n\n"
+            f"CODEX_SHIM_PATH_PREPEND={tc}\n"
+            "CODEX_SHIM_EXEC=pinned-codex --pinned-flag\n"
+        )
+        proc = self.fx.run("-p", "city", "x")
+        self.assert_exec_ok(proc, ["--pinned-flag", "-p", "city", "x"])
+        self.assertEqual(proc.stderr, "")
+        self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), pinned.resolve())
+        self.assertEqual(self.fx.recorded("path"), f"{tc}:{self.fx.bin}:{SYSTEM_PATH}")
+
+    def test_environment_wins_over_the_sidecar(self) -> None:
+        other = self.fx.write_exec(self.fx.root / "other" / "env-codex", FAKE_CODEX)
+        self.fx.write_sidecar("CODEX_SHIM_EXEC=never-runs\nCODEX_SHIM_PATH_PREPEND=/nonexistent-sidecar\n")
+        proc = self.fx.run("-p", "city", env_extra={
+            "CODEX_SHIM_EXEC": "env-codex",
+            "CODEX_SHIM_PATH_PREPEND": str(other.parent),
+        })
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(pathlib.Path(self.fx.recorded("argv0")).resolve(), other.resolve())
+        self.assertTrue(self.fx.recorded("path").startswith(f"{other.parent}:"))
+        self.assertNotIn("/nonexistent-sidecar", self.fx.recorded("path"))
+
+    def test_sidecar_is_not_evaluated_and_quotes_are_stripped(self) -> None:
+        canary = self.fx.root / "canary"
+        self.fx.write_sidecar(f'CODEX_SHIM_EXEC="$(touch {canary})"\n')
+        proc = self.fx.run("-p", "city")
+        self.assertEqual(proc.returncode, 127)
+        self.assertFalse(canary.exists(), "sidecar value was evaluated by a shell")
+        self.assertIn("ERROR no '$(touch' on PATH", proc.stderr)
+        self.fx.write_sidecar("CODEX_SHIM_EXEC='codex --quoted'\n")
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["--quoted", "-p", "city"])
+
+    def test_unknown_sidecar_keys_warn_and_are_ignored(self) -> None:
+        self.fx.write_sidecar("BOGUS=1\nno-equals-line\nCODEX_SHIM_EXEC=codex --ok\n")
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["--ok", "-p", "city"])
+        self.assertIn("WARN ignoring unknown key BOGUS", proc.stderr)
+        self.assertIn("WARN ignoring line without '='", proc.stderr)
+
+    def test_prepend_is_pruned_when_it_names_the_shim_directory(self) -> None:
+        self.fx.write_sidecar(f"CODEX_SHIM_PATH_PREPEND={self.fx.shim_dir}\n")
+        proc = self.fx.run("-p", "city")
+        self.assert_exec_ok(proc, ["-p", "city"])
+        self.assertEqual(self.fx.recorded("path"), f"{self.fx.bin}:{SYSTEM_PATH}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gascity/tests/test_codex_infisical_shim.py
+++ b/gascity/tests/test_codex_infisical_shim.py
@@ -23,7 +23,9 @@ SCRIPT = PACK / "assets" / "scripts" / "codex-infisical-shim.sh"
 README = PACK / "README.md"
 SYSTEM_PATH = "/usr/bin:/bin"
 
-FAKE_CODEX = """#!/bin/sh
+# bash, not sh: Ubuntu's /bin/sh is dash, which ignores an inherited SHELLOPTS,
+# and the inherited-option rows read the fake's view of xtrace/noglob/errexit.
+FAKE_CODEX = """#!/bin/bash
 printf '%s\\n' "${SHELLOPTS-<unset>}" > "$SHIM_TEST_OUT/shellopts"
 set +x
 out="$SHIM_TEST_OUT"
@@ -588,7 +590,7 @@ class CodexInfisicalShimTests(unittest.TestCase):
         self.assertNotIn("minted-dummy-secret", proc.stdout + proc.stderr)
         self.assertEqual(self.fx.recorded("token"), "minted-dummy-secret")
         # A PS4 that expands the token: the shim's own trace lines never print.
-        # The fake, a shell script that inherits xtrace, PS4 and the token by
+        # The fake, a bash script that inherits xtrace, PS4 and the token by
         # design, traces exactly its first two lines before its own `set +x`;
         # every other stderr line would be the shim's.
         proc = self.fx.run("-p", "city", env_extra={


### PR DESCRIPTION
## Why

The Codex provider wrapper that mints an Infisical machine-identity token at session start existed only as city runtime state (`.gc/shims/codex-astra/codex`, written on citadel by gp-e8r6). A rebuilt city, a mirror city, or a runtime reset lost it silently, and the Codex role workers went back to asking for an interactive `infisical login`. Bead gp-3or1.

## What

- **`gascity/assets/scripts/codex-infisical-shim.sh`** (bash, executable), the source of record, beside `worker-worktree.sh`. Contract in the header: fail-open token (source `$HOME/.config/infisical-agent/token.sh` when `INFISICAL_TOKEN` is unset; absent file silent, failing file one WARN and the token unset, the exec happens either way, the token never echoed; a set token is kept); argv intact; never execs itself (every PATH entry that resolves to its own directory is pruned, a target that is the shim file is refused, no codex left exits 127, never a loop); per-city settings from the environment, else a plain `KEY=VALUE` file `<shim>.env` beside it that is never evaluated: `CODEX_SHIM_PATH_PREPEND` (toolchain wrappers first on PATH) and `CODEX_SHIM_EXEC` (a pinned build such as `npx -y @openai/codex@0.153.3`; default `codex` from the pruned PATH). PATH and `INFISICAL_TOKEN` are the only environment writes.
- **Deliberate differences from the extracted copy** (stated in the header): the PATH prepend and the pinned npx command line moved from hardcoded citadel values into `<shim>.env`, so one file installs on any city and the installed copy can be verified by md5; the default exec target and the self-exec guard are new; the WARN prefix names this script.
- **`gascity/README.md`**, new section "Codex provider shim": why a provider `command` wrapper is the one city-side place a minted value enters the session environment (an agent `env` map is static, `pre_start` runs in its own process); the install (`install -m 0755` to `$CITY/.gc/shims/codex-astra/codex`, `codex.env` beside it); the `city.toml` provider keys (`command`, `resume_command`) and the role agents' `provider` + `[env] INFISICAL_PROJECT_ID`; the md5 comparison a city runs at each wake against the pack checkout at the installed pin.
- **`gascity/tests/test_codex_infisical_shim.py`**, 46 rows on a real subprocess (the round-1 set below, then one row per codex finding, see the table) with a recording fake codex and a throwaway HOME: canonical file executable, bash, header carries the recipe; README section carries the recipe; token.sh absent / present (a marker export reaches the exec'd command, the client id is unset again) / failing (one WARN, token unset, still execs) / unreadable / token already set; the shim directory pruned by path, by bare-name PATH lookup, through a symlinked and a relative alias, and through the prepend; no codex left is 127, not a loop; a symlink to the shim elsewhere on PATH and a `CODEX_SHIM_EXEC` naming the shim are refused; the sidecar sets exec and prepend, the environment wins, values are not evaluated (`$(touch canary)` stays literal) and quotes are stripped, unknown keys WARN.

Mutation check on round 1 (each mutation run against the suite, original restored byte-identical): no PATH pruning, 13 rows fail; fail-open removed, 1; argv altered, 13; sidecar evaluated, 3. Every later round's new rows were run against the previous round's shim (counts in the table below).

## City half (not in this PR)

On citadel the installed copy is the gp-e8r6 bash file (md5 `dd377444f841fceacaea366343667673`), which hardcodes the toolchain prepend and `npx -y @openai/codex@0.153.3`. Installing this file in its place needs the two-line `codex.env` from the README beside it; the provider `command` and `resume_command` in `city.toml` and the two role agents' `[env]` stay as they are. The rearm verify row, the memory line and the recipe mail to jadegate are the mayor's.

## Suite

`GC_TEMPLATE` unset (papercut pc_8212e074015a), run on every round's head: `gascity/tests tests/test_gc_role_worker_fragment.py` 281 passed, 9730 subtests passed at the final head (fork main e0be462: 235 / 9730); `tests contributing/tests` 130 passed, 8 skipped. The new file alone: 46 rows. `shellcheck -s bash` clean; `bash -n` under macOS bash 3.2.57.

## Codex

`codex exec --sandbox read-only` on a full-tree snapshot of each head with `review.diff` at the root, one adversarial prompt naming the contract; rulings archived on citadel as `assets/ops/codex-gates/gp-3or1-codex-r{1..7}.out`. Every finding was applied and pinned by a row that fails on the previous round's shim:

| round | verdict | findings, all applied | rows failing on the previous shim |
| --- | --- | --- | --- |
| r1 | BLOCK 3 MAJOR 6 MINOR | self-location needed dirname/basename; helper sourced in-process (exit, `set --`, stray exports); helper stdout leaked the token; empty PATH entries dropped; blank override ran a caller argument; non-empty precedence; scratch names clobbered inherited exports; no mkdir -p; `test "" = ""` md5 check | 13 of 32 |
| r2 | BLOCK 2 MAJOR 4 MINOR | helper trace / EXIT trap escaped the redirect; PATH="" is cwd; CDPATH; inherited `cis_*` as config; `git show | md5` on a bad pin; recipe test skipped on Linux | 6 of 38 |
| r3 | BLOCK 2 MAJOR 2 MINOR | exported function `codex` bypassed the guard (A/B loop); inherited xtrace traced the token; `//` spelling unpruned; `set +f` dropped inherited noglob | 5 of 43 |
| r4 | BLOCK 1 MAJOR 2 MINOR | PS4 expanding the token on the first and the restored trace line; errexit skipped the 127 diagnostic; `cis_argv0` / `cis_token` | 4 of 45 |
| r5 | BLOCK 1 MAJOR | the fake was `/bin/sh` (dash on Ubuntu ignores SHELLOPTS) | test-only |
| r6 | BLOCK 1 MAJOR | `BASH_XTRACEFD=1` (bash >= 4.1) sent the two trace groups to stdout | header pin only on bash 3.2 (no `BASH_XTRACEFD` there); real on the CI bash |
| r7 | **CLEAN** | | |

## Heads

Fork branch `feat/gp-3or1-codex-infisical-shim`, 7 commits on aphexcx/gascity-packs main e0be462, head **211c50b** (tree 64ca6fd). Twin `feat/gp-3or1-codex-infisical-shim-upstream`, the same 7 commits cherry-picked onto gastownhall/gascity-packs main e72252e (DO-NOT 204: cut from upstream main, not from this head), head **f9d06d6**; shim and test file byte-identical, README section identical, its only conflict was the section's anchor (upstream has no Worker workspaces section, the section sits before Build Methodology Contract on both). Twin `gascity/tests` on full-tree copies: base 18 failed / 205 passed, head 18 failed / 251 passed, failure SETS identical.

Canonical file md5 at this head (what the city's rearm row compares the installed `.gc/shims/codex-astra/codex` against): **`294ea8f2ec444a3b69ba3abf16a469fe`**. Recording line from the README, run against this head on citadel, prints the same value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbMBHDLixyk2hNuBzgEUkA
