### PR TITLE
fix(gastown): give every base STOP arm halt ceremony and pin it against drift

### DIFF
--- a/gastown/formulas/mol-polecat-work.toml
+++ b/gastown/formulas/mol-polecat-work.toml
@@ -149,6 +149,15 @@ The STOP arms stamp `halt_reason` and mail the witness on the way out —
 a base misconfiguration needs a human, and an unrecorded exit just loops
 through witness recovery until someone reads session logs.
 
+Every later base STOP arm in this formula owes the same ceremony: step 3's
+`base_branch_vanished` arm and `self-review`'s `base_ref_lost` arm. The
+`base_branch_vanished` case is the one that must never exit bare — a base
+deleted on origin leaves this clone's remote-tracking ref behind, so the
+block above keeps resolving it, and the bead halts identically on every
+witness re-pool. `WITNESS_TARGET` is a shell variable and dies with the
+session exactly as `$BASE_REF` does, so `self-review` re-derives it rather
+than referencing this one across the step boundary.
+
 Every later block in this step uses `$BASE_REF` — never assume
 `origin/{{base_branch}}` exists. `$BASE_REF` is a shell variable and
 dies with this session, so the resolution is also recorded on the work
@@ -259,6 +268,8 @@ elif ! git fetch origin {{base_branch}} >/dev/null 2>&1; then
     else
         echo "STOP: {{base_branch}} no longer resolves on origin (deleted, renamed, or unreachable)."
         echo "Re-run workspace-setup to re-resolve the base; do not branch from a stale ref."
+        gc bd update "$WORK_BEAD_ID" --set-metadata halt_reason=base_branch_vanished
+        gc mail send "$WITNESS_TARGET" -s "polecat halted: base_branch_vanished ($WORK_BEAD_ID)" -m "{{base_branch}} no longer resolves on origin, but this clone's refs/remotes/origin/{{base_branch}} survives the failed fetch, so step 1 keeps resolving it and $WORK_BEAD_ID halts here again every time witness recovery re-pools it. Restore {{base_branch}} on origin, or fix the rig/bead base configuration and prune the stale tracking ref."
         gc runtime drain-ack
         exit 1
     fi
@@ -330,6 +341,11 @@ BASE_REF=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.base_ref // 
 if [ -z "$BASE_REF" ] || ! git rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null; then
     echo "STOP: base ref unresolved (metadata.base_ref='$BASE_REF')."
     echo "Re-run workspace-setup to resolve and record the base; do not substitute a different one."
+    # This step is a fresh session, so workspace-setup's WITNESS_TARGET is not
+    # in scope here — re-derive it rather than mailing an empty target.
+    WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness"
+    gc bd update "$WORK_BEAD_ID" --set-metadata halt_reason=base_ref_lost
+    gc mail send "$WITNESS_TARGET" -s "polecat halted: base_ref_lost ($WORK_BEAD_ID)" -m "metadata.base_ref on $WORK_BEAD_ID is empty or no longer resolves to a commit, so self-review cannot pick the commit set to review. Re-running workspace-setup re-resolves and re-stamps it, so re-pooling the bead is usually enough; if it halts here twice, the recorded base has been deleted."
     gc runtime drain-ack
     exit 1
 fi

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -129,6 +129,14 @@ GASTOWN_BUILD_WORKFLOW_CONTRACTS = {
         "branch_has_real_change",
         'git worktree add --detach "$MERGE_WT" "origin/$TARGET"',
         'git -C "$MERGE_WT" merge --ff-only "$TEMP_SHA"',
+        # The invalid-upstream halt: a missing target is not a merge conflict,
+        # and without this arm one misconfigured `target` blocks every other
+        # merge in the rig. Pin the guard and the typed reason, NOT
+        # `--set-metadata merge_result=blocked` -- that literal occurs twice in
+        # this formula (here and in `block_existing_pr`), so a pin on it
+        # union-joins with the sibling and stays green with this arm deleted.
+        'if ! git show-ref --verify --quiet "refs/remotes/origin/$TARGET"; then',
+        "--set-metadata halt_reason=target_branch_missing",
         "--set-metadata merge_result=merged",
         '--set-metadata merged_sha="$MERGED_SHA"',
         'gc bd close "$WORK" --reason "Merged to $TARGET at $MERGED_SHORT"',
@@ -228,6 +236,30 @@ POLECAT_BASE_REF_REQUIRED_FRAGMENTS = (
     'BASE_LOCAL="refs/heads/{{base_branch}}"',
     'gc bd update "$WORK_BEAD_ID" --set-metadata base_ref="$BASE_REF"',
     "metadata.base_ref",
+    # The ancestry check is the only thing standing between a locally-advanced
+    # base and a silently different fork point; the structural checks below
+    # cannot see it, because it is a nested `if`, not the block's `else` arm.
+    'if git show-ref --verify --quiet "$BASE_LOCAL" && ! git merge-base --is-ancestor "$BASE_LOCAL" "$BASE_REMOTE"; then',
+    # One stamp and one witness mail per base STOP arm. The mail is the
+    # load-bearing half: `halt_reason` has no runtime consumers, so a halt that
+    # only stamps is invisible until a human reads session logs. Each literal
+    # occurs exactly once in the formula, so a deletion cannot union-join with
+    # a sibling arm's copy and stay green.
+    "halt_reason=base_branch_diverged",
+    'gc mail send "$WITNESS_TARGET" -s "polecat halted: base_branch_diverged',
+    "halt_reason=base_branch_missing",
+    'gc mail send "$WITNESS_TARGET" -s "polecat halted: base_branch_missing',
+    "halt_reason=base_branch_vanished",
+    'gc mail send "$WITNESS_TARGET" -s "polecat halted: base_branch_vanished',
+    "halt_reason=base_ref_lost",
+    'gc mail send "$WITNESS_TARGET" -s "polecat halted: base_ref_lost',
+    # `self-review` is a fresh session, so its arm has to re-derive
+    # WITNESS_TARGET or mail an empty target. The bare assignment cannot pin
+    # that: it now occurs twice, so a pin on it is satisfied by the
+    # workspace-setup copy alone and stays green with this one deleted. Pin the
+    # adjacency to the arm it serves instead -- that pair occurs exactly once.
+    '    WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness"\n'
+    '    gc bd update "$WORK_BEAD_ID" --set-metadata halt_reason=base_ref_lost',
 )
 # The resolution block may only ever name one of the two probed refs. Anything
 # else is a substituted base, which is the defect class this lint exists for.

--- a/tests/test_gascity_pack_inference_gate.py
+++ b/tests/test_gascity_pack_inference_gate.py
@@ -1324,6 +1324,54 @@ def test_polecat_base_ref_contract_rejects_a_neutralised_stop_arm(tmp_path) -> N
         gascity_pack_inference_gate.validate_polecat_base_ref_contract(pack_source)
 
 
+def test_polecat_base_ref_contract_rejects_a_neutralised_diverged_arm(tmp_path) -> None:
+    # The sibling above only reaches the block's `else`. The diverged-base arm
+    # is a nested `if`, so every structural check skips it: the stop-arm
+    # assertions never see it, and it kept its `exit 1` here anyway. Stripping
+    # its halt_reason stamp left the whole battery green until the ceremony
+    # fragments were pinned.
+    pack_source = mutated_gastown_source(
+        tmp_path,
+        '        gc bd update "$WORK_BEAD_ID" --set-metadata halt_reason=base_branch_diverged\n',
+        "",
+    )
+
+    with pytest.raises(gascity_pack_inference_gate.GateError, match="base_branch_diverged"):
+        gascity_pack_inference_gate.validate_polecat_base_ref_contract(pack_source)
+
+
+def test_polecat_base_ref_contract_rejects_a_downgraded_witness_mail(tmp_path) -> None:
+    # `halt_reason` has no runtime consumers, so the mail is the only live
+    # signal a halted polecat emits. Downgrading it to an echo keeps the stamp,
+    # the STOP message and the non-zero exit -- so the stamp pin, the stop-arm
+    # assertions and the halt-count pin all stay green -- while the bead halts
+    # silently on every witness re-pool.
+    pack_source = mutated_gastown_source(
+        tmp_path,
+        'gc mail send "$WITNESS_TARGET" -s "polecat halted: base_branch_vanished ($WORK_BEAD_ID)" -m "',
+        'echo "',
+    )
+
+    with pytest.raises(gascity_pack_inference_gate.GateError, match="base_branch_vanished"):
+        gascity_pack_inference_gate.validate_polecat_base_ref_contract(pack_source)
+
+
+def test_polecat_base_ref_contract_rejects_a_dropped_witness_rederivation(tmp_path) -> None:
+    # `self-review` is a fresh session, so dropping the re-derivation mails the
+    # halt to an empty target -- the original defect -- while the stamp, the
+    # mail line, the STOP text and the exit all survive. A pin on the bare
+    # assignment could not catch this: it also matches the workspace-setup
+    # copy. Only the adjacency to the arm it serves is unique.
+    pack_source = mutated_gastown_source(
+        tmp_path,
+        '    WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness"\n',
+        "",
+    )
+
+    with pytest.raises(gascity_pack_inference_gate.GateError, match="base_ref_lost"):
+        gascity_pack_inference_gate.validate_polecat_base_ref_contract(pack_source)
+
+
 def test_polecat_base_ref_contract_rejects_a_missing_stop_arm(tmp_path) -> None:
     pack_source = mutated_gastown_source(
         tmp_path,


### PR DESCRIPTION
Post-merge remediation for #288 (landed range `e013296..e72252e`).

The review returned `request_changes` with one major (F1) and one coupled minor (F2). They land in one commit because F2 is what makes F1 stick — without the pins, F1's fix is reintroducible by the next edit that touches this formula, silently.

## F1 (major) — two of the four base STOP arms exited bare

#288 set the standard in its own prose: a base STOP arm stamps `halt_reason` and mails the witness on the way out, because *"an unrecorded exit just loops through witness recovery until someone reads session logs."* Two of the four arms it left in `mol-polecat-work` do neither — they echo, `gc runtime drain-ack`, and `exit 1`.

**`base_branch_vanished`** (workspace-setup step 3) is the arm that cannot self-heal. The base is gone from origin, but the failed fetch leaves this clone's `refs/remotes/origin/<base>` behind — so step 1's resolution block keeps resolving it and hands the same bead to the same arm on **every** witness re-pool. Silently, indefinitely.

**`base_ref_lost`** (self-review) is milder — re-running workspace-setup re-stamps `metadata.base_ref` — but it is equally invisible while it halts.

Both arms now stamp a distinct typed reason and mail the witness. The reasons are deliberately **not** folded into the two that exist: `base_branch_vanished` (deleted from origin under a live clone) and `base_branch_missing` (never existed) want different human responses, and so do `base_ref_lost` and `base_branch_diverged`.

### The scope bug the review caught

`WITNESS_TARGET` is assigned in workspace-setup at `:123` and used in the same step at `:272` — but `self-review` is a separate `[[steps]]` entry. That is a fresh session, where the variable is gone exactly as `$BASE_REF` is; the formula's own prose already says so about `$BASE_REF`. Mailing `"$WITNESS_TARGET"` from that arm would have addressed an **empty target** — a halt notification that goes nowhere is worse than none, because it reads as delivered.

Verified rather than assumed: the formula has exactly three `[[steps]]` (`:60` `workspace-setup`, `:310` `self-review`, `:424` `submit-and-exit`), so `:123` and `:272` share a step and `:341` does not. The self-review arm re-derives `WITNESS_TARGET` with the byte-identical expression, and the prose now records why the two arms differ.

## F2 (minor) — the new ceremony needed pinning, because the old ceremony had none

Measured on the landed head **before** this change: stripping the `halt_reason` stamp *and* the witness mail from both arms that already had them leaves the entire battery green (`G1` below). The structural lint only ever reaches the resolution block's `else` arm, and the fragment contract pinned resolution literals, not halt ceremony.

`POLECAT_BASE_REF_REQUIRED_FRAGMENTS` now pins, per base STOP arm, the typed reason **and** the witness mail that carries it — for all four arms, not just the two added here, because the measured gap covers all four. The mail is pinned alongside the stamp because `halt_reason` has no runtime consumer: a halt that only stamps is still invisible. The nested ancestry check is pinned too — it is a nested `if`, not the block's `else`, so no structural check can reach it.

### Every pinned literal occurs exactly once, and that is load-bearing

The fragment check is a plain substring test over the whole formula text, so a literal that occurs twice union-joins with its sibling and survives deletion of the arm it was meant to pin.

- The self-review re-derivation is pinned by its **adjacency** to the arm it serves, not by the bare assignment — that literal now occurs twice, so a pin on it would be satisfied by the workspace-setup copy alone.
- For the refinery half, the review offered `--set-metadata merge_result=blocked` as one option. It occurs **twice** in `mol-refinery-patrol` (`:259`, and `block_existing_pr` at `:513`). Measured: deleting the entire invalid-upstream arm still leaves one occurrence, so that pin stays satisfied. Pinned the show-ref guard and `halt_reason=target_branch_missing` instead — one occurrence each, both go to zero.

## Evidence

Every pin was measured rather than assumed to discriminate. All mutations ran in a throwaway `git worktree add --detach` at the landed head, never in the review worktree. 13/13 arms behaved as predicted:

| arm | mutation | expected | pytest |
|---|---|---|---|
| **C0** | *base tree, unmutated (negative control)* | GREEN | 87 passed |
| **C1** | *this tree, unmutated* | GREEN | 90 passed |
| **G1** | ceremony stripped from both arms that had it, **on the landed head** | GREEN | 87 passed |
| **G2** | **same mutation, on this tree** | **RED** | 5 failed |
| **P1** | formula fix + new tests, **pins reverted** | **RED** | 3 failed |
| **F1a** | `base_branch_vanished` stamp deleted | **RED** | 4 failed |
| **F1b** | `base_branch_vanished` witness mail deleted | **RED** | 5 failed |
| **F1c** | `base_ref_lost` stamp deleted | **RED** | 4 failed |
| **F1d** | `base_ref_lost` witness mail deleted | **RED** | 4 failed |
| **F1e** | self-review `WITNESS_TARGET` re-derivation deleted | **RED** | 5 failed |
| **F2a** | ancestry check deleted | **RED** | 6 failed |
| **F2b** | refinery `halt_reason=target_branch_missing` deleted | **RED** | 1 failed |
| **F2c** | refinery show-ref guard deleted | **RED** | 1 failed |

**G1 / G2 are the pair that matters**: the identical mutation is green on the landed head and red here — the reported gap reproduced, then closed. **P1** shows the pins carry it, not the three new tests on their own.

Vacuity control on the alternative refinery pin: with the whole invalid-upstream arm deleted, `merge_result=blocked` still occurs `1×` and a substring pin on it stays **satisfied**; both literals chosen here go to `0×`.

Round-trip checks, because the pins read raw file text while the agent executes the parsed value: all five added shell lines are present verbatim in the **parsed** TOML (not just the raw text), all 28 `bash` fences pass `bash -n`, and neither formula has a second copy in the repo that the stricter pins could break.

## Suites

- `tests/test_gascity_pack_inference_gate.py` — **90 passed** (87 before; +3 mutation tests)
- `gastown/tests/test_polecat_push_gate.sh` — rc 0
- `gastown/tests/test_gastown_pack_assets.sh` — rc 0
- both touched formulas parse under `tomllib`; `git diff --check` clean

## Scope

Applied: F1 and F2 only. Not applied: **F3–F6**, all non-gating follow-ups in the review.

Two deliberate widenings beyond the literal text of F2, both because the narrower version would have shipped an inert pin:

1. Pinned all **four** halt reasons and their mails, not only the two arms this change adds — the measured gap (`G1`) covers all four.
2. Pinned **both** refinery literals where the review said *"or"*, and pinned the self-review re-derivation, which the review did not enumerate — `F1e` shows an unpinned re-derivation is deletable while every other pin stays green, which is precisely the F1 defect returning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
