### PR TITLE
fix(bmad): route gap-analysis-review to acceptance-auditor, not the self-checker

### DIFF
--- a/bmad/formulas/bmad-code-review-flow.formula.toml
+++ b/bmad/formulas/bmad-code-review-flow.formula.toml
@@ -64,7 +64,7 @@ description_file = "../assets/workflows/bmad-code-review-flow/{target}.acceptanc
 [[template.children]]
 id = "{target}.gap-analysis-review"
 title = "BMAD review: gap analysis"
-metadata = { "gc.run_target" = "bmad.story-self-checker" }
+metadata = { "gc.run_target" = "bmad.acceptance-auditor" }
 description_file = "../assets/workflows/bmad-code-review-flow/{target}.gap-analysis-review.md"
 
 [[template.children]]

--- a/gascity/tests/test_formula_assets.py
+++ b/gascity/tests/test_formula_assets.py
@@ -417,7 +417,7 @@ THIRD_PARTY_BUILD_PACKS = {
             "review": "bmad-code-review-flow",
         },
         "review_expansion": "bmad-code-review-flow",
-        "gap_analysis_target": "bmad.story-self-checker",
+        "gap_analysis_target": "bmad.acceptance-auditor",
         "review_fix_asset": "assets/workflows/bmad-code-review-flow/{target}.apply-bmad-review-findings.md",
     },
     "gstack": {

--- a/scripts/gascity_pack_inference_gate.py
+++ b/scripts/gascity_pack_inference_gate.py
@@ -546,7 +546,6 @@ METHODOLOGY_FLOW_CONTRACTS = {
                 "bmad.blind-hunter-reviewer",
                 "bmad.edge-case-reviewer",
                 "bmad.acceptance-auditor",
-                "bmad.story-self-checker",
                 "bmad.bmad-review-synthesizer",
                 "{implementation_target}",
             ),
@@ -761,7 +760,6 @@ def make_pack_specs() -> dict[str, PackSpec]:
                 "bmad.blind-hunter-reviewer",
                 "bmad.edge-case-reviewer",
                 "bmad.acceptance-auditor",
-                "bmad.story-self-checker",
                 "bmad.bmad-review-synthesizer",
             ),
             required_build_routes=(


### PR DESCRIPTION
`bmad-code-review-flow` routed the `{target}.gap-analysis-review` lane to `bmad.story-self-checker` — an implement-phase self-review agent, not a reviewer. Every sibling methodology pack (compound-engineering, superpowers, gstack) routes its gap-analysis lane to a review-phase agent; bmad was the outlier, so the gap-analysis review ran in the wrong agent lane (observed on gascity-pack vault-memory runs 8/9).

This swaps the lane to `bmad.acceptance-auditor` (the gap-analysis-adjacent reviewer) and aligns the two inference-gate route contracts + the formula-assets `gap_analysis_target` table with the corrected route.

**Changes**
- `bmad/formulas/bmad-code-review-flow.formula.toml` — `gap-analysis-review` run_target → `bmad.acceptance-auditor`
- `gascity/tests/test_formula_assets.py` — `gap_analysis_target` aligned to `bmad.acceptance-auditor`
- `scripts/gascity_pack_inference_gate.py` — drop `bmad.story-self-checker` from the two route contracts

**Verification** (from the originating branch): registry validate ok; `pytest` 354 passed / 9471 subtests (only the pre-existing gastown-lint waiver test fails, identically on pristine `origin/main`).

Ref: gascity-pack bead `gp-qz4gg`. Authored by the gascity-pack rig-worker (Claude Fable 5); published via the mayor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWzm5aR3J3X6F7Qjqr6reb
