### PR TITLE
fix(gastown): patrol formulas misattribute recycle pacing to session_sleep

### DIFF
--- a/gastown/assets/scripts/witness-heartbeat-check.sh
+++ b/gastown/assets/scripts/witness-heartbeat-check.sh
@@ -71,8 +71,8 @@ if [ -z "${GC_CITY:-}" ] || [ ! -f "$GC_CITY/city.toml" ]; then
 fi
 
 # Default window: the gastown witness does NOT self-schedule a ~60s wakeup — it
-# ends its turn with `IDLE:` and the controller's session_sleep policy restarts
-# it, bounded by the witness agent's idle_timeout of 1h. 1h is therefore the
+# ends its turn with `IDLE:` and the controller's idle_timeout (1h for the
+# witness agent) recycles it. 1h is therefore the
 # longest legitimate silence for a healthy witness, so the window sits at 1.5x
 # that. Well clear of legitimate idle, and still an order of magnitude under the
 # 14h floor of the stalls this check exists to catch. Lower it only if your

--- a/gastown/formulas/mol-deacon-patrol.toml
+++ b/gastown/formulas/mol-deacon-patrol.toml
@@ -579,7 +579,8 @@ Write exactly:
 IDLE: no work, exiting turn.
 ```
 Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
-The session_sleep policy will restart this session after the configured idle interval;
-the next wisp is already assigned and the restarted session resumes from it.
+The idle_timeout (1h for this agent) will recycle this session after the idle
+interval; the next wisp is already assigned and the recycled session re-reads
+the formula and resumes from the beads ledger.
 
 **Exit criteria:** Next wisp poured and assigned, this wisp burned, turn ended with IDLE signal."""

--- a/gastown/formulas/mol-refinery-patrol.toml
+++ b/gastown/formulas/mol-refinery-patrol.toml
@@ -214,8 +214,9 @@ Write exactly:
 IDLE: no work, exiting turn.
 ```
 Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
-The session_sleep policy will restart this session after the configured idle interval.
-When restarted, re-read formula steps — this step stays open until a work bead is found.
+The idle_timeout (2h for this agent) will recycle this session after the idle
+interval. When recycled, re-read formula steps — this step stays open until a
+work bead is found.
 
 **Do not close this step until you have a work bead with branch metadata.**"""
 

--- a/gastown/formulas/mol-witness-patrol.toml
+++ b/gastown/formulas/mol-witness-patrol.toml
@@ -854,7 +854,8 @@ Write exactly:
 IDLE: no work, exiting turn.
 ```
 Then stop immediately. Do NOT sleep, call ScheduleWakeup, or use Monitor.
-The session_sleep policy will restart this session after the configured idle interval;
-the next wisp is already assigned and the restarted session resumes from it.
+The idle_timeout (1h for this agent) will recycle this session after the idle
+interval; the next wisp is already assigned and the recycled session re-reads
+the formula and resumes from the beads ledger.
 
 **Exit criteria:** Next wisp poured, this wisp burned, turn ended with IDLE signal."""

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -183,13 +183,15 @@ test_work_bead_resolution_discriminator_is_pinned() {
     # The third precondition lives in the formula, not in agent.toml, so neither
     # pin above can ever catch its loss: the deacon pours the successor, burns
     # this wisp, and EXITS the turn, so one process env holds exactly one wisp
-    # for its whole life and the restarted session gets a fresh trigger. An
-    # in-session loop here revives the stale-trigger failure with both config
-    # pins still green.
+    # for its whole life and the idle_timeout-recycled session gets a fresh
+    # trigger. An in-session loop here revives the stale-trigger failure with
+    # both config pins still green.
     grep -F 'IDLE: no work, exiting turn.' "$deacon" >/dev/null ||
         fail "the deacon's trigger-first wisp resolution is safe only while each iteration ends by exiting the turn; mol-deacon-patrol.toml no longer emits the IDLE exit signal"
-    grep -F 'the recycled session' "$deacon" >/dev/null ||
-        fail "the deacon's trigger-first wisp resolution is safe only while the successor wisp is resumed by a RECYCLED session (fresh trigger via idle_timeout); mol-deacon-patrol.toml no longer hands the successor to a recycled session"
+    grep -F 'the next wisp is already assigned and the recycled session re-reads' "$deacon" >/dev/null ||
+        fail "the deacon's trigger-first wisp resolution is safe only while the exit step states the handoff contract part 1 (successor already assigned); mol-deacon-patrol.toml no longer states the handoff"
+    grep -F 'the formula and resumes from the beads ledger' "$deacon" >/dev/null ||
+        fail "the deacon's trigger-first wisp resolution is safe only while the exit step states the handoff contract part 2 (the idle_timeout-recycled session re-reads the formula and resumes from the beads ledger); mol-deacon-patrol.toml no longer states the handoff"
     ! grep -F 're-read formula steps to begin' "$deacon" >/dev/null ||
         fail "the deacon now rotates wisps in-session like the refinery, so its spawn trigger goes stale mid-loop; mol-deacon-patrol.toml must drop the trigger-preferring resolution for the bare \${GC_BEAD_ID:-} plus live assignee query"
 

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -188,8 +188,8 @@ test_work_bead_resolution_discriminator_is_pinned() {
     # pins still green.
     grep -F 'IDLE: no work, exiting turn.' "$deacon" >/dev/null ||
         fail "the deacon's trigger-first wisp resolution is safe only while each iteration ends by exiting the turn; mol-deacon-patrol.toml no longer emits the IDLE exit signal"
-    grep -F 'the restarted session resumes from it' "$deacon" >/dev/null ||
-        fail "the deacon's trigger-first wisp resolution is safe only while the successor wisp is resumed by a RESTARTED session (fresh trigger); mol-deacon-patrol.toml no longer hands the successor to a restarted session"
+    grep -F 'the recycled session' "$deacon" >/dev/null ||
+        fail "the deacon's trigger-first wisp resolution is safe only while the successor wisp is resumed by a RECYCLED session (fresh trigger via idle_timeout); mol-deacon-patrol.toml no longer hands the successor to a recycled session"
     ! grep -F 're-read formula steps to begin' "$deacon" >/dev/null ||
         fail "the deacon now rotates wisps in-session like the refinery, so its spawn trigger goes stale mid-loop; mol-deacon-patrol.toml must drop the trigger-preferring resolution for the bare \${GC_BEAD_ID:-} plus live assignee query"
 


### PR DESCRIPTION
## Summary

The deacon, refinery, and witness patrol formulas end their idle exit step with:

> The session_sleep policy will restart this session after the configured idle interval; the next wisp is already assigned and the restarted session resumes from it.

Both halves are wrong for these agents, and `witness-heartbeat-check.sh`'s stale-window comment repeats the misattribution.

## What's actually true

**`session_sleep` never restarts anything.** The idle-sleep policy (gascity `engdocs/design/idle-session-sleep.md`) drains a safely-idle session to `state=asleep` (`sleep_reason=idle`) and wakes it **on demand only** — `WakeWork`, `WakeWait`, `WakeAttached`, pending interaction, or dependency propagation. The design's own migration table draws the line explicitly:

| Knob | Trigger | Post-action |
|---|---|---|
| `idle_timeout` | no activity for timeout | **stop and restart** |
| `sleep_after_idle` | safe idle + no hard wake reason | **drain to asleep; wake on demand** |

Timer-based recycle is `idle_timeout` — restart-on-idle, a different knob — which is what these agents actually configure: deacon `1h`, refinery `2h`, witness `1h` (their `agent.toml`s).

**"The restarted session resumes from it" is also wrong here.** All three agents run `wake_mode = "fresh"`: every wake starts a new provider context. The successor wisp in the beads ledger carries the state; the session resumes nothing.

## Why it matters

The claim is latent rather than active — `idle_timeout` does arrive, so patrol loops keep turning. But an agent (or maintainer) that trusts the stated contract mis-diagnoses patrol stalls: it waits on a "session_sleep restart" that is never coming, and attributes the eventual recycle to the wrong mechanism. The deacon-stall postmortems in this pack are precisely about patrol contracts that were believed rather than true.

## Changes

- `mol-deacon-patrol.toml` (exit step): "The `idle_timeout` (1h for this agent) will recycle this session after the idle interval; the next wisp is already assigned and the recycled session re-reads the formula and resumes from the beads ledger."
- `mol-refinery-patrol.toml` (find-work idle branch): same correction, 2h.
- `mol-witness-patrol.toml` (exit step): same correction, 1h.
- `witness-heartbeat-check.sh` (comment): keeps its correct operative mechanism (the witness `idle_timeout` of 1h bounding the stale window); only the wrong feature name is removed.
- `test_gastown_pack_assets.sh`: the deacon exit block is pinned by the old string "the restarted session resumes from it". The pin's stated purpose is the successor-handoff property, so the pin now targets both halves of the corrected contract sentence (the contract wraps across two TOML lines, hence two line-scoped pins), and the adjacent "restarted session gets a fresh trigger" comment is updated to the recycle model.

## Scope note

Boot's deacon-observation status-pin blindness is intentionally **not** this PR — that is #420's scope. The `session_sleep` misattribution is covered by no open PR (#396/#411 touch adjacent formula lines; neither references `session_sleep`).

## Verification

- `gastown/tests/test_gastown_pack_assets.sh` passes; negative-tested the new handoff pins (mutating either contract half fails the suite).
- `tests/test_no_bare_bd_commands.py`, `tests/test_gastown_lint_findings.py`: OK.
- `gc lint gastown`: no new findings vs `main`.
- `session_sleep` semantics verified against the accepted design doc and the installed `gc` binary's config surface (`[session_sleep]`, `sleep_after_idle`, `idle_timeout`); `wake_mode`/`idle_timeout` values read from each agent's `agent.toml`.
- Adversarially reviewed (cross-family critic): first pass REJECT (pin too weak, stale comment), fixed; second pass APPROVE.
