### PR TITLE
fix(gastown): resume assigned refinery patrol roots

### DIFF
--- a/gastown/agents/refinery/agent.toml
+++ b/gastown/agents/refinery/agent.toml
@@ -5,3 +5,4 @@ nudge = "Run 'gc prime' to check merge queue and begin processing."
 pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
 idle_timeout = "2h"
 max_active_sessions = 1
+work_query = """gc bd list ${GC_RIG:+--rig="$GC_RIG"} --include-infra --assignee="$GC_AGENT" --status=open,in_progress --type=molecule --title="mol-refinery-patrol" --sort=created --limit=0 --json | jq -c '[.[] | select(.title == "mol-refinery-patrol")]'"""

--- a/gastown/agents/refinery/prompt.template.md
+++ b/gastown/agents/refinery/prompt.template.md
@@ -173,12 +173,42 @@ for ORPHAN in $ORPHANS; do
   # surfaces beads the inbox missed.
 done
 
-# Step 1: Check for an in-progress patrol wisp
-{{ .AssignedInProgressQuery }}
+# Step 1: Atomically resume an assigned open or in-progress patrol wisp.
+# The refinery agent's work_query is deliberately restricted to this rig,
+# assignee, and exact mol-refinery-patrol title, so merge work cannot be
+# mistaken for the lifecycle root.
+CLAIM=$(gc hook --claim --json)
+CLAIM_STATUS=$?
+CLAIM_ACTION=$(printf '%s' "$CLAIM" | jq -r '.action // empty')
+CLAIM_REASON=$(printf '%s' "$CLAIM" | jq -r '.reason // empty')
+if [ "$CLAIM_ACTION" = "work" ]; then
+  WISP=$(printf '%s' "$CLAIM" | jq -r '.bead_id // empty')
+elif [ "$CLAIM_STATUS" -eq 1 ] && [ "$CLAIM_ACTION" = "drain" ] && [ "$CLAIM_REASON" = "no_work" ]; then
+  WISP=""
+else
+  echo "Could not safely classify the refinery patrol claim result; not pouring."
+  gc runtime drain-ack
+  exit 1
+fi
 
-# If none found, pour one (root-only — no child step beads) and assign it
-WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$WISP" --assignee="$GC_AGENT"
+# Only an explicit no_work drain result may pour a root. Assign it, then promote that
+# exact open successor through the same atomic claim path before proceeding.
+if [ -z "$WISP" ]; then
+  WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$WISP" ] || ! gc bd update "$WISP" --assignee="$GC_AGENT"; then
+    echo "Could not create and assign a refinery patrol wisp."
+    gc runtime drain-ack
+    exit 1
+  fi
+  CLAIM=$(gc hook --claim --json)
+  CLAIM_STATUS=$?
+  CLAIMED_WISP=$(printf '%s' "$CLAIM" | jq -r 'select(.action == "work") | .bead_id // empty')
+  if [ "$CLAIM_STATUS" -ne 0 ] || [ "$CLAIMED_WISP" != "$WISP" ]; then
+    echo "Could not atomically claim the newly assigned refinery patrol wisp; preserving it for recovery."
+    gc runtime drain-ack
+    exit 1
+  fi
+fi
 ```
 
 Then follow the formula. The step descriptions below are your instructions —

--- a/gastown/tests/test_gastown_pack_assets.sh
+++ b/gastown/tests/test_gastown_pack_assets.sh
@@ -277,6 +277,104 @@ test_polecat_startup_uses_standard_hook_claim() {
         fail "polecat propulsion fragment must not regress to an unclaimed hook/work-query choice"
 }
 
+test_refinery_startup_claims_assigned_patrol_before_pour() {
+    local agent prompt startup
+    agent="$GASTOWN/agents/refinery/agent.toml"
+    prompt="$GASTOWN/agents/refinery/prompt.template.md"
+    startup="$(sed -n '/^## Startup$/,/^## Sequential Rebase Protocol$/p' "$prompt")"
+
+    # Refinery successors are assigned while still open. A startup query that
+    # sees only in_progress roots misses every waiting successor and pours one
+    # more on each context restart. Keep the agent's atomic hook candidate set
+    # exact: this rig, this assignee, molecule roots, this patrol formula, and
+    # both resumable statuses. The final jq equality check prevents a similarly
+    # named foreign molecule from entering the claim path.
+    for want in \
+        'work_query = """gc bd list' \
+        '--include-infra' \
+        '--assignee="$GC_AGENT"' \
+        '--status=open,in_progress' \
+        '--type=molecule' \
+        '--title="mol-refinery-patrol"' \
+        '--sort=created --limit=0 --json' \
+        'select(.title == "mol-refinery-patrol")'; do
+        grep -F -- "$want" "$agent" >/dev/null ||
+        fail "refinery work_query missing assigned-open patrol selector: $want"
+    done
+    ! grep -F '.[:1]' "$agent" >/dev/null ||
+        fail "refinery work_query must return every exact candidate so hook ranking can prefer in_progress"
+
+    # The startup must run the standard atomic claim before its only pour. The
+    # second claim promotes a just-poured open successor before formula work.
+    # This makes an empty queue stable across completion and process/context
+    # restarts instead of depending on a read-then-write race in prompt shell.
+    [[ "$(grep -cF 'gc hook --claim --json' <<<"$startup")" -eq 2 ]] ||
+        fail "refinery startup must atomically claim both existing and just-poured patrol roots"
+    [[ "$(grep -cF 'gc bd mol wisp mol-refinery-patrol' <<<"$startup")" -eq 1 ]] ||
+        fail "refinery startup must have exactly one guarded fallback pour"
+    grep -F '[ "$CLAIM_ACTION" = "drain" ] && [ "$CLAIM_REASON" = "no_work" ]' <<<"$startup" >/dev/null ||
+        fail "refinery startup must pour only after an explicit no_work claim result"
+    grep -F 'not pouring' <<<"$startup" >/dev/null ||
+        fail "refinery startup must fail closed on malformed or operational claim failures"
+    python3 - "$prompt" <<'PY' || fail "refinery startup must claim before pouring and verify the fallback claim"
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+startup = text.split("## Startup", 1)[1].split("## Sequential Rebase Protocol", 1)[0]
+first_claim = startup.index("gc hook --claim --json")
+pour = startup.index("gc bd mol wisp mol-refinery-patrol")
+second_claim = startup.index("gc hook --claim --json", first_claim + 1)
+verified = startup.index('[ "$CLAIMED_WISP" != "$WISP" ]')
+if not first_claim < pour < second_claim < verified:
+    raise SystemExit("claim/pour/claim-verification order is unsafe")
+if "{{ .AssignedInProgressQuery }}" in startup:
+    raise SystemExit("legacy in_progress-only startup query still present")
+PY
+
+    # Executable state model for the escaped regression: an assigned open root
+    # is claimed rather than duplicated, and two empty restarts converge on the
+    # same single root. Unrelated molecules are outside the configured selector.
+    python3 <<'PY' || fail "refinery restart model accumulated patrol roots"
+roots = []
+foreign = [{"id": "foreign", "title": "mol-witness-patrol", "status": "open"}]
+
+def restart():
+    candidates = [r for r in roots if r["title"] == "mol-refinery-patrol" and r["status"] in {"open", "in_progress"}]
+    if candidates:
+        ranked = sorted(candidates, key=lambda r: (r["status"] != "in_progress", r["created"]))
+        ranked[0]["status"] = "in_progress"
+        return ranked[0]["id"]
+    root = {"id": f"patrol-{len(roots) + 1}", "title": "mol-refinery-patrol", "status": "open", "created": len(roots) + 1}
+    roots.append(root)
+    root["status"] = "in_progress"
+    return root["id"]
+
+assert restart() == "patrol-1"
+roots[0]["status"] = "open"  # successor waiting across a fresh context
+assert restart() == "patrol-1"
+roots[0]["status"] = "open"  # process restart repeats the same boundary
+assert restart() == "patrol-1"
+assert len(roots) == 1
+assert foreign == [{"id": "foreign", "title": "mol-witness-patrol", "status": "open"}]
+
+# Query/claim failures are not an empty queue and must never authorize a pour.
+before = list(roots)
+claim_result = {"action": "drain", "reason": "claims_errored"}
+if claim_result == {"action": "drain", "reason": "no_work"}:
+    roots.append({"id": "unsafe", "title": "mol-refinery-patrol", "status": "open"})
+assert roots == before
+
+# Hook ranking, not query truncation, preserves a legitimate current root when
+# historical assigned-open successors are also present.
+roots = [
+    {"id": "old-open", "title": "mol-refinery-patrol", "status": "open", "created": 1},
+    {"id": "current", "title": "mol-refinery-patrol", "status": "in_progress", "created": 2},
+]
+assert restart() == "current"
+assert roots[0]["status"] == "open"
+PY
+}
+
 test_review_leg_contract_forbids_synthetic_mutation() {
     local formula prompt
     formula="$GASTOWN/formulas/mol-review-leg.toml"
@@ -695,6 +793,7 @@ test_shutdown_dance_lifecycle_and_audit_contracts
 test_work_bead_resolution_discriminator_is_pinned
 test_composition_is_documented
 test_polecat_startup_uses_standard_hook_claim
+test_refinery_startup_claims_assigned_patrol_before_pour
 test_review_leg_contract_forbids_synthetic_mutation
 test_prime_prompts_are_city_generic_and_compact
 test_witness_wisp_queries_pin_include_infra


### PR DESCRIPTION
## Summary

- give the refinery an exact, rig-scoped patrol-root work query that includes assigned `open` and `in_progress` molecules
- atomically claim an existing patrol through `gc hook --claim` before the only fallback pour
- fail closed unless the hook explicitly reports `drain/no_work`, then verify the newly poured root is the one claimed
- retain the full candidate set so hook ranking preserves an existing in-progress patrol over older open roots

## Root cause

Refinery successors are assigned while still `open`, but the startup prompt checked only `in_progress` roots. Each context/process restart therefore missed every waiting successor and poured another root. A prior read-then-write reconciliation proposal was race-prone; this change uses the existing atomic hook claim boundary instead.

## Tests

- `for test_script in gastown/tests/test_*.sh; do bash "$test_script"; done`
- `go test .`
- `go vet .`
- `python3 -m pytest tests contributing/tests gascity/tests discord/tests github/tests oversight-rig/tests slack-full/tests slack-channel/tests pr-pipeline/tests profiler/tests -q` (1596 passed, 39 skipped, 9586 subtests)
- independent review approved repaired candidate `d73ab6967c7dc0790136173cfe14ac85d5642d0a`

Tracks Gas City bead `ga-b5s` and source issue `gp-rd6a`.